### PR TITLE
jersey-apache-client must updated to jersey-apache-client4 because of vulnarability

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -36,7 +36,7 @@
     </dependency>
     <dependency>
       <groupId>com.sun.jersey.contribs</groupId>
-      <artifactId>jersey-apache-client</artifactId>
+      <artifactId>jersey-apache-client4</artifactId>
       <version>1.17.1</version>
       <scope>compile</scope>
     </dependency>


### PR DESCRIPTION
Hi! Can you please pull this change?

Httpclient 3.x has descibed vulnarability: http://web.nvd.nist.gov/view/vuln/detail?vulnId=CVE-2012-5783. It is used by jersey-apache-client. In the same time there is jersey-apache-client4 library that it using httpclient 4.1.1. I've replaced old jersy-apache-client with jersy-apache-client4 artifact.

I investigated the code and did not find that you are using jersey-apache-client at all. Maybe I miss something?
com.sun.jersey.api.client.Client is always initialized to use com.sun.jersey.client.urlconnection.URLConnectionClientHandler that uses HttpURLConnection or HttpsURLConnection to make HTTP requests and receive HTTP responses. So no Httpclient at all.
