### PR TITLE
Update TransactionalClick JSON parsing

### DIFF
--- a/src/com/createsend/models/transactional/response/TransactionalClick.java
+++ b/src/com/createsend/models/transactional/response/TransactionalClick.java
@@ -38,7 +38,7 @@ public class TransactionalClick {
     @JsonProperty("Geolocation")
     private GeoLocation geoLocation;
 
-    @JsonProperty("URL")
+    @JsonProperty("Url")
     private String url;
 
     /**


### PR DESCRIPTION
At some point the Message Details API changed the case of the url key in the returned JSON from "URL" to "Url." This change is not reflected in their documentation, but when you make a curl you can see the discrepancy. It causes the getUrl method to return null for all responses from the API.
