### PR TITLE
[squid:S2259] Null pointers should not be dereferenced

### DIFF
--- a/src/com/createsend/util/JerseyClientImpl.java
+++ b/src/com/createsend/util/JerseyClientImpl.java
@@ -471,9 +471,11 @@ public class JerseyClientImpl implements JerseyClient {
             } catch (ClassNotFoundException e) { }
         }
         
-        for(Method method : klass.getMethods()) {
-            if(method.getName().equals(callingMethodName)) {
-                return (ParameterizedType)method.getGenericReturnType();
+        if (klass != null) {
+            for (Method method : klass.getMethods()) {
+                if (method.getName().equals(callingMethodName)) {
+                    return (ParameterizedType) method.getGenericReturnType();
+                }
             }
         }
         


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule 
squid:S2259 - “Null pointers should not be dereferenced”. 

You can find more information about the issue here: 
https://dev.eclipse.org/sonar/rules/show/squid:S2259

Please let me know if you have any questions.
Ayman Abdelghany.