### PR TITLE
[squid:UselessImportCheck] Useless imports should be removed

### DIFF
--- a/samples/com/createsend/samples/TransactionalSample.java
+++ b/samples/com/createsend/samples/TransactionalSample.java
@@ -29,7 +29,6 @@ import com.createsend.models.transactional.request.Attachment;
 import com.createsend.models.transactional.request.ClassicEmailRequest;
 import com.createsend.models.transactional.request.SmartEmailRequest;
 import com.createsend.models.transactional.response.*;
-import com.createsend.util.ApiKeyAuthenticationDetails;
 import com.createsend.util.OAuthAuthenticationDetails;
 import com.createsend.util.exceptions.CreateSendException;
 

--- a/src/com/createsend/General.java
+++ b/src/com/createsend/General.java
@@ -28,7 +28,6 @@ import java.util.Date;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.MultivaluedMap;
 
-import com.createsend.models.ApiKey;
 import com.createsend.models.ExternalSessionOptions;
 import com.createsend.models.ExternalSessionResult;
 import com.createsend.models.OAuthTokenDetails;
@@ -41,7 +40,6 @@ import com.createsend.util.Configuration;
 import com.createsend.util.JerseyClient;
 import com.createsend.util.JerseyClientImpl;
 import com.createsend.util.exceptions.CreateSendException;
-import com.createsend.util.jersey.AuthorisedResourceFactory;
 import com.sun.jersey.core.util.MultivaluedMapImpl;
 
 /**

--- a/src/com/createsend/models/transactional/request/SmartEmailRequest.java
+++ b/src/com/createsend/models/transactional/request/SmartEmailRequest.java
@@ -22,7 +22,6 @@
 package com.createsend.models.transactional.request;
 
 import org.codehaus.jackson.annotate.JsonIgnore;
-import org.codehaus.jackson.annotate.JsonUnwrapped;
 
 import java.util.*;
 

--- a/src/com/createsend/models/transactional/response/MessageSent.java
+++ b/src/com/createsend/models/transactional/response/MessageSent.java
@@ -23,8 +23,6 @@ package com.createsend.models.transactional.response;
 
 import org.codehaus.jackson.annotate.JsonProperty;
 
-import java.util.Date;
-import java.util.List;
 import java.util.UUID;
 
 public class MessageSent {

--- a/src/com/createsend/util/jersey/JsonProvider.java
+++ b/src/com/createsend/util/jersey/JsonProvider.java
@@ -27,7 +27,6 @@ import java.io.OutputStream;
 import java.lang.annotation.Annotation;
 import java.lang.reflect.Type;
 import java.text.DateFormat;
-import java.text.FieldPosition;
 import java.text.ParsePosition;
 import java.text.SimpleDateFormat;
 import java.util.Date;
@@ -37,7 +36,6 @@ import javax.ws.rs.core.MultivaluedMap;
 
 import org.codehaus.jackson.jaxrs.JacksonJsonProvider;
 import org.codehaus.jackson.map.DeserializationConfig;
-import org.codehaus.jackson.map.JsonMappingException;
 import org.codehaus.jackson.map.ObjectMapper;
 import org.codehaus.jackson.map.annotate.JsonSerialize.Inclusion;
 


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule 
squid:UselessImportCheck - “Useless imports should be removed”. 

You can find more information about the issue here: 
https://dev.eclipse.org/sonar/rules/show/squid:UselessImportCheck

Please let me know if you have any questions.
Ayman Abdelghany.
