### PR TITLE
Point deactivate webhook to the correct endpoint

### DIFF
--- a/src/com/createsend/Lists.java
+++ b/src/com/createsend/Lists.java
@@ -562,6 +562,6 @@ public class Lists extends CreateSendBase {
      * Activating a webhook</a>
      */
     public void deactivateWebhook(String webhookID) throws CreateSendException {
-        jerseyClient.put("", "lists", listID, "webhooks", webhookID, "activate.json");
+        jerseyClient.put("", "lists", listID, "webhooks", webhookID, "deactivate.json");
     }
 }


### PR DESCRIPTION
Just a simple fix to point the List deactivate webhook to the correct endpoint bases on the docs:
https://www.campaignmonitor.com/api/lists/#deactivating-a-webhook