### PR TITLE
Updated to API version 3.2 - include ConsentToTrack field

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,5 +1,13 @@
 # createsend-java history
 
+## v6.0.0 - 28 May 2018
+
+* Upgrades to Createsend API v3.2 which includes new breaking changes
+* Breaking: 'Consent to track' field is now mandatory for sending smart and classic transactional emails
+* Breaking: 'Consent to track' field is now mandatory when adding or updating subscribers
+* Optional 'Include tracking preference' field when retrieving lists of subscribers
+* Fix 'Add recipient to list ID' field when sending classic transactional emails
+
 ## v5.1.3 - 14 Jun 2017
 
 * Undo v5.1.2; instead configure JavaDoc generation to not fail on errors. Sonatype insists on JavaDoc :-P 

--- a/build.gradle
+++ b/build.gradle
@@ -7,7 +7,7 @@ install.dependsOn ':build'
 defaultTasks 'clean', 'install'
 
 sourceCompatibility = 1.7
-version = '5.1.3'
+version = '6.0.0'
 group = 'com.createsend'
 
 def localMavenRepo = 'file://' + new File(System.getProperty('user.home'), '.m2/repository').absolutePath

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>com.createsend</groupId>
   <artifactId>createsend-java</artifactId>
-  <version>5.1.4-SNAPSHOT</version>
+  <version>6.0.0-SNAPSHOT</version>
   <name>createsend-java</name>
   <description>A Java library which implements the complete functionality of the Campaign Monitor API.</description>
   <url>http://campaignmonitor.github.io/createsend-java/</url>

--- a/samples/com/createsend/samples/SampleRunner.java
+++ b/samples/com/createsend/samples/SampleRunner.java
@@ -56,6 +56,7 @@ import com.createsend.models.people.PersonToAdd;
 import com.createsend.models.segments.Rule;
 import com.createsend.models.segments.RuleGroup;
 import com.createsend.models.segments.Segment;
+import com.createsend.models.subscribers.ConsentToTrack;
 import com.createsend.models.subscribers.CustomField;
 import com.createsend.models.subscribers.Subscriber;
 import com.createsend.models.subscribers.SubscriberToAdd;

--- a/samples/com/createsend/samples/SampleRunner.java
+++ b/samples/com/createsend/samples/SampleRunner.java
@@ -140,6 +140,7 @@ public class SampleRunner {
         SubscriberToAdd subscriber = new SubscriberToAdd();
         subscriber.Resubscribe = true;
         subscriber.EmailAddress = "Subscriber Email 1";
+        subscriber.ConsentToTrack = ConsentToTrack.UNCHANGED;
         subscriber.Name = "Java Test Sub 1";
         subscriber.CustomFields = new CustomField[] {
             new CustomField()
@@ -151,6 +152,7 @@ public class SampleRunner {
         
         String originalEmail = subscriber.EmailAddress;
         subscriber.EmailAddress = "New Subscriber Email Address";
+        subscriber.ConsentToTrack = ConsentToTrack.UNCHANGED;
         subscriber.CustomFields = null; // We don't want to update any custom fields
         subscriber.Name = "New Subscriber Name";
         subscriberAPI.update(originalEmail, subscriber);  
@@ -167,13 +169,16 @@ public class SampleRunner {
         };
         
         subscribers.Subscribers[0].EmailAddress = "Subscriber Email 1";
+        subscribers.Subscribers[0].ConsentToTrack = ConsentToTrack.UNCHANGED;
         subscribers.Subscribers[0].CustomFields = new CustomField[] { new CustomField() };
         subscribers.Subscribers[0].CustomFields[0].Key = key;
         subscribers.Subscribers[0].CustomFields[0].Clear = true; // remove website from this existing subscriber
         
         subscribers.Subscribers[1].EmailAddress = "Subscriber Email 2";
-        
+        subscribers.Subscribers[1].ConsentToTrack = ConsentToTrack.YES;
+
         subscribers.Subscribers[2].EmailAddress = "Subscriber Email 3";
+        subscribers.Subscribers[2].ConsentToTrack = ConsentToTrack.NO;
         subscribers.Subscribers[2].CustomFields = new CustomField[] { new CustomField() };
         subscribers.Subscribers[2].CustomFields[0].Key = key;
         subscribers.Subscribers[2].CustomFields[0].Value = "http://www.google.com";
@@ -208,7 +213,7 @@ public class SampleRunner {
         segmentAPI.create(listAPI.getListID(), segment);
         System.out.printf("Result of create segment: %s\n", segmentAPI.getSegmentID());
         System.out.printf("Result of segment details: %s\n", segmentAPI.details());
-        System.out.printf("Result of segment active: %s\n",  segmentAPI.active(subscribersFrom, null, null, null, null));
+        System.out.printf("Result of segment active: %s\n",  segmentAPI.active(subscribersFrom, null, null, null, null, true));
 
         segment.Title = "New Java Test Segment";
         segment.RuleGroups[0].Rules[0].Clause = "CONTAINS hotmail.com";

--- a/samples/com/createsend/samples/TransactionalSample.java
+++ b/samples/com/createsend/samples/TransactionalSample.java
@@ -24,6 +24,7 @@ package com.createsend.samples;
 import com.createsend.ClassicEmail;
 import com.createsend.Messages;
 import com.createsend.SmartEmail;
+import com.createsend.models.subscribers.ConsentToTrack;
 import com.createsend.models.transactional.EmailContent;
 import com.createsend.models.transactional.request.Attachment;
 import com.createsend.models.transactional.request.ClassicEmailRequest;

--- a/samples/com/createsend/samples/TransactionalSample.java
+++ b/samples/com/createsend/samples/TransactionalSample.java
@@ -105,7 +105,7 @@ public class TransactionalSample {
 
         ClassicEmail classicEmail = new ClassicEmail(auth);
 
-        ClassicEmailRequest classicEmailRequest = new ClassicEmailRequest(toAddress);
+        ClassicEmailRequest classicEmailRequest = new ClassicEmailRequest(toAddress, ConsentToTrack.UNCHANGED);
         classicEmailRequest.setFrom(fromAddress);
         classicEmailRequest.setReplyTo(replyToAddress);
         classicEmailRequest.setSubject(subject);
@@ -167,7 +167,7 @@ public class TransactionalSample {
         System.out.println("---- Send Smart Email ----");
 
         SmartEmail smartEmail = new SmartEmail(auth);
-        SmartEmailRequest smartEmailRequest = new SmartEmailRequest(smartEmailID, toAddress);
+        SmartEmailRequest smartEmailRequest = new SmartEmailRequest(smartEmailID, toAddress, ConsentToTrack.UNCHANGED);
         smartEmailRequest.addData("myvariable", "supplied via the wrapper sample runner");
 
         Attachment attachment = getAttachment();

--- a/src/com/createsend/ClassicEmail.java
+++ b/src/com/createsend/ClassicEmail.java
@@ -32,7 +32,7 @@ import com.sun.jersey.core.util.MultivaluedMapImpl;
 import javax.ws.rs.core.MultivaluedMap;
 
 /**
- * Provides methods for accessing all <a href="http://www.campaignmonitor.com/api/transactional/classicEmail/" target="_blank">
+ * Provides methods for accessing all <a href="https://www.campaignmonitor.com/api/transactional/" target="_blank">
  * Transactional Classic Email</a> resources in the Campaign Monitor API
  */
 public class ClassicEmail extends CreateSendBase {

--- a/src/com/createsend/Lists.java
+++ b/src/com/createsend/Lists.java
@@ -178,7 +178,19 @@ public class Lists extends CreateSendBase {
      * Getting active subscribers</a>
      */
     public PagedResult<Subscriber> active() throws CreateSendException {
-        return active(1, 1000, "email", "asc");
+        return active(1, 1000, "email", "asc", false);
+    }
+
+    /**
+     * Gets a paged collection of active subscribers who have subscribed to the list.
+     * @param includeTrackingPreference To include subscriber consent to track value in the results.
+     * @return The paged subscribers returned by the api call.
+     * @throws CreateSendException Thrown when the API responds with a HTTP Status >= 400
+     * @see <a href="http://www.campaignmonitor.com/api/lists/#active_subscribers" target="_blank">
+     * Getting active subscribers</a>
+     */
+    public PagedResult<Subscriber> active(boolean includeTrackingPreference) throws CreateSendException {
+        return active(1, 1000, "email", "asc", includeTrackingPreference);
     }
 
     /**
@@ -192,9 +204,26 @@ public class Lists extends CreateSendBase {
      * @see <a href="http://www.campaignmonitor.com/api/lists/#active_subscribers" target="_blank">
      * Getting active subscribers</a>
      */
-    public PagedResult<Subscriber> active(
-            Integer page, Integer pageSize, String orderField, String orderDirection) throws CreateSendException {
-        return active("", page, pageSize, orderField, orderDirection);
+    public PagedResult<Subscriber> active(Integer page, Integer pageSize,
+        String orderField, String orderDirection) throws CreateSendException {
+        return active("", page, pageSize, orderField, orderDirection, false);
+    }
+
+    /**
+     * Gets a paged collection of active subscribers who have subscribed to the list.
+     * @param page The page number or results to get. Use <code>null</code> for the default (page=1)
+     * @param pageSize The number of records to get on the current page. Use <code>null</code> for the default.
+     * @param orderField The field used to order the results by. Use <code>null</code> for the default.
+     * @param orderDirection The direction to order the results by. Use <code>null</code> for the default.
+     * @param includeTrackingPreference To include subscriber consent to track value in the results.
+     * @return The paged subscribers returned by the api call.
+     * @throws CreateSendException Thrown when the API responds with a HTTP Status >= 400
+     * @see <a href="http://www.campaignmonitor.com/api/lists/#active_subscribers" target="_blank">
+     * Getting active subscribers</a>
+     */
+    public PagedResult<Subscriber> active(Integer page, Integer pageSize, String orderField,
+        String orderDirection, boolean includeTrackingPreference) throws CreateSendException {
+        return active("", page, pageSize, orderField, orderDirection, includeTrackingPreference);
     }
 
     /**
@@ -211,17 +240,39 @@ public class Lists extends CreateSendBase {
      * @see <a href="http://www.campaignmonitor.com/api/lists/#active_subscribers" target="_blank">
      * Getting active subscribers</a>
      */
-    public PagedResult<Subscriber> active(Date subscribedFrom,
-            Integer page, Integer pageSize, String orderField, String orderDirection) throws CreateSendException {
+    public PagedResult<Subscriber> active(Date subscribedFrom, Integer page, Integer pageSize,
+        String orderField, String orderDirection) throws CreateSendException {
         return active(JsonProvider.ApiDateFormat.format(subscribedFrom),
-                page, pageSize, orderField, orderDirection);
+                page, pageSize, orderField, orderDirection, false);
+    }
+
+    /**
+     * Gets a paged collection of active subscribers who have subscribed to the list
+     * since the provided date.
+     * @param subscribedFrom The API will only return subscribers who became active on or after this date.
+     *     This field is required
+     * @param page The page number or results to get. Use <code>null</code> for the default (page=1)
+     * @param pageSize The number of records to get on the current page. Use <code>null</code> for the default.
+     * @param orderField The field used to order the results by. Use <code>null</code> for the default.
+     * @param orderDirection The direction to order the results by. Use <code>null</code> for the default.
+     * @param includeTrackingPreference To include subscriber consent to track value in the results.
+     * @return The paged subscribers returned by the api call.
+     * @throws CreateSendException Thrown when the API responds with a HTTP Status >= 400
+     * @see <a href="http://www.campaignmonitor.com/api/lists/#active_subscribers" target="_blank">
+     * Getting active subscribers</a>
+     */
+    public PagedResult<Subscriber> active(Date subscribedFrom, Integer page, Integer pageSize,
+        String orderField, String orderDirection, boolean includeTrackingPreference) throws CreateSendException {
+        return active(JsonProvider.ApiDateFormat.format(subscribedFrom),
+            page, pageSize, orderField, orderDirection, includeTrackingPreference);
     }
     
-    private PagedResult<Subscriber> active(String subscribedFrom,
-        Integer page, Integer pageSize, String orderField, String orderDirection) throws CreateSendException {
+    private PagedResult<Subscriber> active(String subscribedFrom, Integer page, Integer pageSize,
+        String orderField, String orderDirection, boolean includeTrackingPreference) throws CreateSendException {
         MultivaluedMap<String, String> queryString = new MultivaluedMapImpl(); 
         queryString.add("date", subscribedFrom);
-        
+        queryString.add("includetrackingpreference", String.valueOf(includeTrackingPreference));
+
         return jerseyClient.getPagedResult(page, pageSize, orderField, orderDirection,
             queryString, "lists", listID, "active.json");
     }
@@ -234,7 +285,19 @@ public class Lists extends CreateSendBase {
      * Getting active subscribers</a>
      */
     public PagedResult<Subscriber> unconfirmed() throws CreateSendException {
-        return unconfirmed(1, 1000, "email", "asc");
+        return unconfirmed(1, 1000, "email", "asc", false);
+    }
+
+    /**
+     * Gets a paged collection of unconfirmed subscribers who have subscribed to the list.
+     * @param includeTrackingPreference To include subscriber consent to track value in the results.
+     * @return The paged subscribers returned by the api call.
+     * @throws CreateSendException Thrown when the API responds with a HTTP Status >= 400
+     * @see <a href="http://www.campaignmonitor.com/api/lists/#unconfirmed_subscribers" target="_blank">
+     * Getting active subscribers</a>
+     */
+    public PagedResult<Subscriber> unconfirmed(boolean includeTrackingPreference) throws CreateSendException {
+        return unconfirmed(1, 1000, "email", "asc", includeTrackingPreference);
     }
 
     /**
@@ -248,9 +311,26 @@ public class Lists extends CreateSendBase {
      * @see <a href="http://www.campaignmonitor.com/api/lists/#unconfirmed_subscribers" target="_blank">
      * Getting active subscribers</a>
      */
-    public PagedResult<Subscriber> unconfirmed(
-            Integer page, Integer pageSize, String orderField, String orderDirection) throws CreateSendException {
-        return unconfirmed("", page, pageSize, orderField, orderDirection);
+    public PagedResult<Subscriber> unconfirmed(Integer page, Integer pageSize,
+        String orderField, String orderDirection) throws CreateSendException {
+        return unconfirmed("", page, pageSize, orderField, orderDirection, false);
+    }
+
+    /**
+     * Gets a paged collection of unconfirmed subscribers who have subscribed to the list.
+     * @param page The page number or results to get. Use <code>null</code> for the default (page=1)
+     * @param pageSize The number of records to get on the current page. Use <code>null</code> for the default.
+     * @param orderField The field used to order the results by. Use <code>null</code> for the default.
+     * @param orderDirection The direction to order the results by. Use <code>null</code> for the default.
+     * @param includeTrackingPreference To include subscriber consent to track value in the results.
+     * @return The paged subscribers returned by the api call.
+     * @throws CreateSendException Thrown when the API responds with a HTTP Status >= 400
+     * @see <a href="http://www.campaignmonitor.com/api/lists/#unconfirmed_subscribers" target="_blank">
+     * Getting active subscribers</a>
+     */
+    public PagedResult<Subscriber> unconfirmed(Integer page, Integer pageSize, String orderField,
+        String orderDirection, boolean includeTrackingPreference) throws CreateSendException {
+        return unconfirmed("", page, pageSize, orderField, orderDirection, includeTrackingPreference);
     }
 
     /**
@@ -267,17 +347,39 @@ public class Lists extends CreateSendBase {
      * @see <a href="http://www.campaignmonitor.com/api/lists/#unconfirmed_subscribers" target="_blank">
      * Getting active subscribers</a>
      */
-    public PagedResult<Subscriber> unconfirmed(Date subscribedFrom,
-            Integer page, Integer pageSize, String orderField, String orderDirection) throws CreateSendException {
+    public PagedResult<Subscriber> unconfirmed(Date subscribedFrom, Integer page, Integer pageSize,
+        String orderField, String orderDirection) throws CreateSendException {
         return unconfirmed(JsonProvider.ApiDateFormat.format(subscribedFrom),
-                page, pageSize, orderField, orderDirection);
+                page, pageSize, orderField, orderDirection, false);
+    }
+
+    /**
+     * Gets a paged collection of unconfirmed subscribers who have subscribed to the list
+     * since the provided date.
+     * @param subscribedFrom The API will only return subscribers who subscribed on or after this date.
+     *     This field is required
+     * @param page The page number or results to get. Use <code>null</code> for the default (page=1)
+     * @param pageSize The number of records to get on the current page. Use <code>null</code> for the default.
+     * @param orderField The field used to order the results by. Use <code>null</code> for the default.
+     * @param orderDirection The direction to order the results by. Use <code>null</code> for the default.
+     * @param includeTrackingPreference To include subscriber consent to track value in the results.
+     * @return The paged subscribers returned by the api call.
+     * @throws CreateSendException Thrown when the API responds with a HTTP Status >= 400
+     * @see <a href="http://www.campaignmonitor.com/api/lists/#unconfirmed_subscribers" target="_blank">
+     * Getting active subscribers</a>
+     */
+    public PagedResult<Subscriber> unconfirmed(Date subscribedFrom, Integer page, Integer pageSize,
+        String orderField, String orderDirection, boolean includeTrackingPreference) throws CreateSendException {
+        return unconfirmed(JsonProvider.ApiDateFormat.format(subscribedFrom),
+            page, pageSize, orderField, orderDirection, includeTrackingPreference);
     }
     
-    private PagedResult<Subscriber> unconfirmed(String subscribedFrom,
-        Integer page, Integer pageSize, String orderField, String orderDirection) throws CreateSendException {
+    private PagedResult<Subscriber> unconfirmed(String subscribedFrom, Integer page,
+        Integer pageSize, String orderField, String orderDirection, boolean includeTrackingPreference) throws CreateSendException {
         MultivaluedMap<String, String> queryString = new MultivaluedMapImpl(); 
         queryString.add("date", subscribedFrom);
-        
+        queryString.add("includetrackingpreference", String.valueOf(includeTrackingPreference));
+
         return jerseyClient.getPagedResult(page, pageSize, orderField, orderDirection,
             queryString, "lists", listID, "unconfirmed.json");
     }
@@ -290,8 +392,21 @@ public class Lists extends CreateSendBase {
      * Getting unsubscribed subscribers</a>
      */
     public PagedResult<Subscriber> unsubscribed() throws CreateSendException {
-        return unsubscribed(1, 1000, "email", "asc");
+        return unsubscribed(1, 1000, "email", "asc", false);
     }
+
+    /**
+     * Gets a paged collection of unsubscribed subscribers who have unsubscribed from the list.
+     * @param includeTrackingPreference To include subscriber consent to track value in the results.
+     * @return The paged subscribers returned by the api call.
+     * @throws CreateSendException Thrown when the API responds with a HTTP Status >= 400
+     * @see <a href="http://www.campaignmonitor.com/api/lists/#unsubscribed_subscribers" target="_blank">
+     * Getting unsubscribed subscribers</a>
+     */
+    public PagedResult<Subscriber> unsubscribed(boolean includeTrackingPreference) throws CreateSendException {
+        return unsubscribed(1, 1000, "email", "asc", includeTrackingPreference);
+    }
+
 
     /**
      * Gets a paged collection of unsubscribed subscribers who have unsubscribed from the list.
@@ -304,9 +419,26 @@ public class Lists extends CreateSendBase {
      * @see <a href="http://www.campaignmonitor.com/api/lists/#unsubscribed_subscribers" target="_blank">
      * Getting unsubscribed subscribers</a>
      */
-    public PagedResult<Subscriber> unsubscribed(
-            Integer page, Integer pageSize, String orderField, String orderDirection) throws CreateSendException {
-        return unsubscribed("", page, pageSize, orderField, orderDirection);
+    public PagedResult<Subscriber> unsubscribed(Integer page, Integer pageSize,
+        String orderField, String orderDirection) throws CreateSendException {
+        return unsubscribed("", page, pageSize, orderField, orderDirection, false);
+    }
+
+    /**
+     * Gets a paged collection of unsubscribed subscribers who have unsubscribed from the list.
+     * @param page The page number or results to get. Use <code>null</code> for the default (page=1)
+     * @param pageSize The number of records to get on the current page. Use <code>null</code> for the default.
+     * @param orderField The field used to order the results by. Use <code>null</code> for the default.
+     * @param orderDirection The direction to order the results by. Use <code>null</code> for the default.
+     * @param includeTrackingPreference To include subscriber consent to track value in the results.
+     * @return The paged subscribers returned by the api call.
+     * @throws CreateSendException Thrown when the API responds with a HTTP Status >= 400
+     * @see <a href="http://www.campaignmonitor.com/api/lists/#unsubscribed_subscribers" target="_blank">
+     * Getting unsubscribed subscribers</a>
+     */
+    public PagedResult<Subscriber> unsubscribed(Integer page, Integer pageSize,
+        String orderField, String orderDirection, boolean includeTrackingPreference) throws CreateSendException {
+        return unsubscribed("", page, pageSize, orderField, orderDirection, includeTrackingPreference);
     }
 
     /**
@@ -322,17 +454,39 @@ public class Lists extends CreateSendBase {
      * @see <a href="http://www.campaignmonitor.com/api/lists/#unsubscribed_subscribers" target="_blank">
      * Getting unsubscribed subscribers</a>
      */
-    public PagedResult<Subscriber> unsubscribed(Date subscribedFrom,
-            Integer page, Integer pageSize, String orderField, String orderDirection) throws CreateSendException {
+    public PagedResult<Subscriber> unsubscribed(Date subscribedFrom, Integer page,
+        Integer pageSize, String orderField, String orderDirection) throws CreateSendException {
         return unsubscribed(JsonProvider.ApiDateFormat.format(subscribedFrom),
-                page, pageSize, orderField, orderDirection);
+                page, pageSize, orderField, orderDirection, false);
     }
 
-    private PagedResult<Subscriber> unsubscribed(String subscribedFrom,
-        Integer page, Integer pageSize, String orderField, String orderDirection) throws CreateSendException {
+    /**
+     * Gets a paged collection of unsubscribed subscribers who have unsubscribed from the list
+     * since the provided date.
+     * @param subscribedFrom The API will only return subscribers who unsubscribed on or after this date.
+     * @param page The page number or results to get. Use <code>null</code> for the default (page=1)
+     * @param pageSize The number of records to get on the current page. Use <code>null</code> for the default.
+     * @param orderField The field used to order the results by. Use <code>null</code> for the default.
+     * @param orderDirection The direction to order the results by. Use <code>null</code> for the default.
+     * @param includeTrackingPreference To include subscriber consent to track value in the results.
+     * @return The paged subscribers returned by the api call.
+     * @throws CreateSendException Thrown when the API responds with a HTTP Status >= 400
+     * @see <a href="http://www.campaignmonitor.com/api/lists/#unsubscribed_subscribers" target="_blank">
+     * Getting unsubscribed subscribers</a>
+     */
+    public PagedResult<Subscriber> unsubscribed(Date subscribedFrom, Integer page, Integer pageSize,
+        String orderField, String orderDirection, boolean includeTrackingPreference) throws CreateSendException {
+        return unsubscribed(JsonProvider.ApiDateFormat.format(subscribedFrom),
+            page, pageSize, orderField, orderDirection, includeTrackingPreference);
+    }
+
+
+    private PagedResult<Subscriber> unsubscribed(String subscribedFrom, Integer page, Integer pageSize,
+        String orderField, String orderDirection, boolean includeTrackingPreference) throws CreateSendException {
         MultivaluedMap<String, String> queryString = new MultivaluedMapImpl(); 
         queryString.add("date", subscribedFrom);
-        
+        queryString.add("includetrackingpreference", String.valueOf(includeTrackingPreference));
+
         return jerseyClient.getPagedResult(page, pageSize, orderField, orderDirection,
             queryString, "lists", listID, "unsubscribed.json");
     }
@@ -345,7 +499,19 @@ public class Lists extends CreateSendBase {
      * Getting deleted subscribers</a>
      */
     public PagedResult<Subscriber> deleted() throws CreateSendException {
-        return deleted(1, 1000, "email", "asc");
+        return deleted(1, 1000, "email", "asc", false);
+    }
+
+    /**
+     * Gets a paged collection of subscribers who have been deleted from the list.
+     * @param includeTrackingPreference To include subscriber consent to track value in the results.
+     * @return The paged subscribers returned by the api call.
+     * @throws CreateSendException Thrown when the API responds with a HTTP Status >= 400
+     * @see <a href="http://www.campaignmonitor.com/api/lists/#deleted_subscribers" target="_blank">
+     * Getting deleted subscribers</a>
+     */
+    public PagedResult<Subscriber> deleted(boolean includeTrackingPreference) throws CreateSendException {
+        return deleted(1, 1000, "email", "asc", includeTrackingPreference);
     }
 
     /**
@@ -359,9 +525,26 @@ public class Lists extends CreateSendBase {
      * @see <a href="http://www.campaignmonitor.com/api/lists/#deleted_subscribers" target="_blank">
      * Getting deleted subscribers</a>
      */
-    public PagedResult<Subscriber> deleted(
-            Integer page, Integer pageSize, String orderField, String orderDirection) throws CreateSendException {
-        return deleted("", page, pageSize, orderField, orderDirection);
+    public PagedResult<Subscriber> deleted(Integer page, Integer pageSize, String orderField,
+        String orderDirection) throws CreateSendException {
+        return deleted("", page, pageSize, orderField, orderDirection, false);
+    }
+
+    /**
+     * Gets a paged collection of subscribers who have been deleted from the list.
+     * @param page The page number or results to get. Use <code>null</code> for the default (page=1)
+     * @param pageSize The number of records to get on the current page. Use <code>null</code> for the default.
+     * @param orderField The field used to order the results by. Use <code>null</code> for the default.
+     * @param orderDirection The direction to order the results by. Use <code>null</code> for the default.
+     * @param includeTrackingPreference To include subscriber consent to track value in the results.
+     * @return The paged subscribers returned by the api call.
+     * @throws CreateSendException Thrown when the API responds with a HTTP Status >= 400
+     * @see <a href="http://www.campaignmonitor.com/api/lists/#deleted_subscribers" target="_blank">
+     * Getting deleted subscribers</a>
+     */
+    public PagedResult<Subscriber> deleted(Integer page, Integer pageSize, String orderField,
+        String orderDirection, boolean includeTrackingPreference) throws CreateSendException {
+        return deleted("", page, pageSize, orderField, orderDirection, includeTrackingPreference);
     }
 
     /**
@@ -377,17 +560,38 @@ public class Lists extends CreateSendBase {
      * @see <a href="http://www.campaignmonitor.com/api/lists/#deleted_subscribers" target="_blank">
      * Getting deleted subscribers</a>
      */
-    public PagedResult<Subscriber> deleted(Date subscribedFrom,
-            Integer page, Integer pageSize, String orderField, String orderDirection) throws CreateSendException {
+    public PagedResult<Subscriber> deleted(Date subscribedFrom,Integer page, Integer pageSize,
+        String orderField, String orderDirection) throws CreateSendException {
         return deleted(JsonProvider.ApiDateFormat.format(subscribedFrom),
-                page, pageSize, orderField, orderDirection);
+                page, pageSize, orderField, orderDirection, false);
+    }
+
+    /**
+     * Gets a paged collection of subscribers who have been deleted from the list
+     * since the provided date.
+     * @param subscribedFrom The API will only return subscribers who were deleted on or after this date.
+     * @param page The page number or results to get. Use <code>null</code> for the default (page=1)
+     * @param pageSize The number of records to get on the current page. Use <code>null</code> for the default.
+     * @param orderField The field used to order the results by. Use <code>null</code> for the default.
+     * @param orderDirection The direction to order the results by. Use <code>null</code> for the default.
+     * @param includeTrackingPreference To include subscriber consent to track value in the results.
+     * @return The paged subscribers returned by the api call.
+     * @throws CreateSendException Thrown when the API responds with a HTTP Status >= 400
+     * @see <a href="http://www.campaignmonitor.com/api/lists/#deleted_subscribers" target="_blank">
+     * Getting deleted subscribers</a>
+     */
+    public PagedResult<Subscriber> deleted(Date subscribedFrom, Integer page, Integer pageSize,
+        String orderField, String orderDirection, boolean includeTrackingPreference) throws CreateSendException {
+        return deleted(JsonProvider.ApiDateFormat.format(subscribedFrom),
+            page, pageSize, orderField, orderDirection, includeTrackingPreference);
     }
     
-    private PagedResult<Subscriber> deleted(String subscribedFrom,
-        Integer page, Integer pageSize, String orderField, String orderDirection) throws CreateSendException {
+    private PagedResult<Subscriber> deleted(String subscribedFrom, Integer page, Integer pageSize,
+        String orderField, String orderDirection, boolean includeTrackingPreference) throws CreateSendException {
         MultivaluedMap<String, String> queryString = new MultivaluedMapImpl(); 
         queryString.add("date", subscribedFrom);
-        
+        queryString.add("includetrackingpreference", String.valueOf(includeTrackingPreference));
+
         return jerseyClient.getPagedResult(page, pageSize, orderField, orderDirection,
             queryString, "lists", listID, "deleted.json");
     }
@@ -400,7 +604,19 @@ public class Lists extends CreateSendBase {
      * Getting bounced subscribers</a>
      */
     public PagedResult<Subscriber> bounced() throws CreateSendException {
-        return bounced(1, 1000, "email", "asc");
+        return bounced(1, 1000, "email", "asc", false);
+    }
+
+    /**
+     * Gets a paged collection of bounced subscribers who have bounced out of the list.
+     * @param includeTrackingPreference To include subscriber consent to track value in the results.
+     * @return The paged subscribers returned by the api call.
+     * @throws CreateSendException Thrown when the API responds with a HTTP Status >= 400
+     * @see <a href="http://www.campaignmonitor.com/api/lists/#bounced_subscribers" target="_blank">
+     * Getting bounced subscribers</a>
+     */
+    public PagedResult<Subscriber> bounced(boolean includeTrackingPreference) throws CreateSendException {
+        return bounced(1, 1000, "email", "asc", includeTrackingPreference);
     }
 
     /**
@@ -414,9 +630,26 @@ public class Lists extends CreateSendBase {
      * @see <a href="http://www.campaignmonitor.com/api/lists/#bounced_subscribers" target="_blank">
      * Getting bounced subscribers</a>
      */
-    public PagedResult<Subscriber> bounced(
-            Integer page, Integer pageSize, String orderField, String orderDirection) throws CreateSendException {
-        return bounced("", page, pageSize, orderField, orderDirection);
+    public PagedResult<Subscriber> bounced(Integer page, Integer pageSize,
+        String orderField, String orderDirection) throws CreateSendException {
+        return bounced("", page, pageSize, orderField, orderDirection, false);
+    }
+
+    /**
+     * Gets a paged collection of bounced subscribers who have bounced out of the list.
+     * @param page The page number or results to get. Use <code>null</code> for the default (page=1)
+     * @param pageSize The number of records to get on the current page. Use <code>null</code> for the default.
+     * @param orderField The field used to order the results by. Use <code>null</code> for the default.
+     * @param orderDirection The direction to order the results by. Use <code>null</code> for the default.
+     * @param includeTrackingPreference To include subscriber consent to track value in the results.
+     * @return The paged subscribers returned by the api call.
+     * @throws CreateSendException Thrown when the API responds with a HTTP Status >= 400
+     * @see <a href="http://www.campaignmonitor.com/api/lists/#bounced_subscribers" target="_blank">
+     * Getting bounced subscribers</a>
+     */
+    public PagedResult<Subscriber> bounced(Integer page, Integer pageSize, String orderField,
+        String orderDirection, boolean includeTrackingPreference) throws CreateSendException {
+        return bounced("", page, pageSize, orderField, orderDirection, includeTrackingPreference);
     }
 
     /**
@@ -432,17 +665,38 @@ public class Lists extends CreateSendBase {
      * @see <a href="http://www.campaignmonitor.com/api/lists/#bounced_subscribers" target="_blank">
      * Getting bounced subscribers</a>
      */
-    public PagedResult<Subscriber> bounced(Date subscribedFrom,
-            Integer page, Integer pageSize, String orderField, String orderDirection) throws CreateSendException {
+    public PagedResult<Subscriber> bounced(Date subscribedFrom, Integer page,
+        Integer pageSize, String orderField, String orderDirection) throws CreateSendException {
         return bounced(JsonProvider.ApiDateFormat.format(subscribedFrom),
-                page, pageSize, orderField, orderDirection);
+                page, pageSize, orderField, orderDirection, false);
     }
 
-    private PagedResult<Subscriber> bounced(String subscribedFrom,
-        Integer page, Integer pageSize, String orderField, String orderDirection) throws CreateSendException {
+    /**
+     * Gets a paged collection of bounced subscribers who have bounced out of the list
+     * since the provided date.
+     * @param subscribedFrom The API will only return subscribers who bounced out on or after this date.
+     * @param page The page number or results to get. Use <code>null</code> for the default (page=1)
+     * @param pageSize The number of records to get on the current page. Use <code>null</code> for the default.
+     * @param orderField The field used to order the results by. Use <code>null</code> for the default.
+     * @param orderDirection The direction to order the results by. Use <code>null</code> for the default.
+     * @param includeTrackingPreference To include subscriber consent to track value in the results.
+     * @return The paged subscribers returned by the api call.
+     * @throws CreateSendException Thrown when the API responds with a HTTP Status >= 400
+     * @see <a href="http://www.campaignmonitor.com/api/lists/#bounced_subscribers" target="_blank">
+     * Getting bounced subscribers</a>
+     */
+    public PagedResult<Subscriber> bounced(Date subscribedFrom, Integer page, Integer pageSize,
+        String orderField, String orderDirection, boolean includeTrackingPreference) throws CreateSendException {
+        return bounced(JsonProvider.ApiDateFormat.format(subscribedFrom),
+            page, pageSize, orderField, orderDirection, includeTrackingPreference);
+    }
+
+    private PagedResult<Subscriber> bounced(String subscribedFrom, Integer page, Integer pageSize,
+        String orderField, String orderDirection, boolean includeTrackingPreference) throws CreateSendException {
         MultivaluedMap<String, String> queryString = new MultivaluedMapImpl(); 
         queryString.add("date", subscribedFrom);
-        
+        queryString.add("includetrackingpreference", String.valueOf(includeTrackingPreference));
+
         return jerseyClient.getPagedResult(page, pageSize, orderField, orderDirection,
             queryString, "lists", listID, "bounced.json");
     }

--- a/src/com/createsend/Lists.java
+++ b/src/com/createsend/Lists.java
@@ -97,7 +97,7 @@ public class Lists extends CreateSendBase {
      * @param list The details of the new list
      * @return The ID of the newly created list
      * @throws CreateSendException Thrown when the API responds with a HTTP Status >= 400
-     * @see <a href="http://www.campaignmonitor.com/api/lists/#creating_a_list" target="_blank">
+     * @see <a href="https://www.campaignmonitor.com/api/lists/#creating-a-list" target="_blank">
      * Creating a list</a>
      */
     public String create(String clientID, List list) throws CreateSendException {
@@ -109,7 +109,7 @@ public class Lists extends CreateSendBase {
      * Updates the basic list details for an existing subscriber list
      * @param list The new basic details for the list
      * @throws CreateSendException Thrown when the API responds with a HTTP Status >= 400
-     * @see <a href="http://www.campaignmonitor.com/api/lists/#updating_a_list" target="_blank">
+     * @see <a href="https://www.campaignmonitor.com/api/lists/#updating-a-list" target="_blank">
      * Updating a list</a>
      */
     public void update(ListForUpdate list) throws CreateSendException {
@@ -119,7 +119,7 @@ public class Lists extends CreateSendBase {
     /**
      * Deletes the list with the specified ID
      * @throws CreateSendException Thrown when the API responds with a HTTP Status >= 400
-     * @see <a href="http://www.campaignmonitor.com/api/lists/#deleting_a_list" target="_blank">
+     * @see <a href="https://www.campaignmonitor.com/api/lists/#deleting-a-list" target="_blank">
      * Deleting a list</a>
      */
     public void delete() throws CreateSendException {
@@ -130,7 +130,7 @@ public class Lists extends CreateSendBase {
      * Gets the details of the list with the given ID
      * @return The details of the list with the given ID
      * @throws CreateSendException Raised when the API returns a HTTP Status >= 400
-     * @see <a href="http://www.campaignmonitor.com/api/lists/#getting_list_details" target="_blank">
+     * @see <a href="https://www.campaignmonitor.com/api/lists/#list-details" target="_blank">
      * Getting list details</a>
      */
     public List details() throws CreateSendException {
@@ -141,7 +141,7 @@ public class Lists extends CreateSendBase {
      * Gets subscriber statistics for the list with the specified ID
      * @return Subscriber statistics for the list with the specified ID
      * @throws CreateSendException Raised when the API responds with HTTP status >= 400
-     * @see <a href="http://www.campaignmonitor.com/api/lists/#getting_list_stats" target="_blank">
+     * @see <a href="https://www.campaignmonitor.com/api/lists/#list-stats" target="_blank">
      * Getting list stats</a>
      */
     public Statistics stats() throws CreateSendException {
@@ -152,7 +152,7 @@ public class Lists extends CreateSendBase {
      * Gets the custom fields available for the list with the specified ID
      * @return The custom fields available for the specified list
      * @throws CreateSendException Raised when the API responds with HTTP Status >= 400
-     * @see <a href="http://www.campaignmonitor.com/api/lists/#getting_list_custom_fields" target="_blank">
+     * @see <a href="https://www.campaignmonitor.com/api/lists/#list-custom-fields" target="_blank">
      * Getting list custom fields</a>
      */
     public CustomField[] customFields() throws CreateSendException {
@@ -163,7 +163,7 @@ public class Lists extends CreateSendBase {
      * Gets the segments available in the list with the specified ID
      * @return The segments available in the specified list
      * @throws CreateSendException Raised when the API responds with HTTP Status >= 400
-     * @see <a href="http://www.campaignmonitor.com/api/lists/#getting_list_segments" target="_blank">
+     * @see <a href="https://www.campaignmonitor.com/api/lists/#list-segments" target="_blank">
      * Getting list segments</a>
      */
     public Segment[] segments() throws CreateSendException {
@@ -174,7 +174,7 @@ public class Lists extends CreateSendBase {
      * Gets a paged collection of active subscribers who have subscribed to the list.
      * @return The paged subscribers returned by the api call.
      * @throws CreateSendException Thrown when the API responds with a HTTP Status >= 400
-     * @see <a href="http://www.campaignmonitor.com/api/lists/#active_subscribers" target="_blank">
+     * @see <a href="https://www.campaignmonitor.com/api/lists/#active-subscribers" target="_blank">
      * Getting active subscribers</a>
      */
     public PagedResult<Subscriber> active() throws CreateSendException {
@@ -186,7 +186,7 @@ public class Lists extends CreateSendBase {
      * @param includeTrackingPreference To include subscriber consent to track value in the results.
      * @return The paged subscribers returned by the api call.
      * @throws CreateSendException Thrown when the API responds with a HTTP Status >= 400
-     * @see <a href="http://www.campaignmonitor.com/api/lists/#active_subscribers" target="_blank">
+     * @see <a href="https://www.campaignmonitor.com/api/lists/#active-subscribers" target="_blank">
      * Getting active subscribers</a>
      */
     public PagedResult<Subscriber> active(boolean includeTrackingPreference) throws CreateSendException {
@@ -201,7 +201,7 @@ public class Lists extends CreateSendBase {
      * @param orderDirection The direction to order the results by. Use <code>null</code> for the default.
      * @return The paged subscribers returned by the api call.
      * @throws CreateSendException Thrown when the API responds with a HTTP Status >= 400
-     * @see <a href="http://www.campaignmonitor.com/api/lists/#active_subscribers" target="_blank">
+     * @see <a href="https://www.campaignmonitor.com/api/lists/#active-subscribers" target="_blank">
      * Getting active subscribers</a>
      */
     public PagedResult<Subscriber> active(Integer page, Integer pageSize,
@@ -218,7 +218,7 @@ public class Lists extends CreateSendBase {
      * @param includeTrackingPreference To include subscriber consent to track value in the results.
      * @return The paged subscribers returned by the api call.
      * @throws CreateSendException Thrown when the API responds with a HTTP Status >= 400
-     * @see <a href="http://www.campaignmonitor.com/api/lists/#active_subscribers" target="_blank">
+     * @see <a href="https://www.campaignmonitor.com/api/lists/#active-subscribers" target="_blank">
      * Getting active subscribers</a>
      */
     public PagedResult<Subscriber> active(Integer page, Integer pageSize, String orderField,
@@ -237,7 +237,7 @@ public class Lists extends CreateSendBase {
      * @param orderDirection The direction to order the results by. Use <code>null</code> for the default.
      * @return The paged subscribers returned by the api call.
      * @throws CreateSendException Thrown when the API responds with a HTTP Status >= 400
-     * @see <a href="http://www.campaignmonitor.com/api/lists/#active_subscribers" target="_blank">
+     * @see <a href="https://www.campaignmonitor.com/api/lists/#active-subscribers" target="_blank">
      * Getting active subscribers</a>
      */
     public PagedResult<Subscriber> active(Date subscribedFrom, Integer page, Integer pageSize,
@@ -258,7 +258,7 @@ public class Lists extends CreateSendBase {
      * @param includeTrackingPreference To include subscriber consent to track value in the results.
      * @return The paged subscribers returned by the api call.
      * @throws CreateSendException Thrown when the API responds with a HTTP Status >= 400
-     * @see <a href="http://www.campaignmonitor.com/api/lists/#active_subscribers" target="_blank">
+     * @see <a href="https://www.campaignmonitor.com/api/lists/#active-subscribers" target="_blank">
      * Getting active subscribers</a>
      */
     public PagedResult<Subscriber> active(Date subscribedFrom, Integer page, Integer pageSize,
@@ -281,7 +281,7 @@ public class Lists extends CreateSendBase {
      * Gets a paged collection of unconfirmed subscribers who have subscribed to the list.
      * @return The paged subscribers returned by the api call.
      * @throws CreateSendException Thrown when the API responds with a HTTP Status >= 400
-     * @see <a href="http://www.campaignmonitor.com/api/lists/#unconfirmed_subscribers" target="_blank">
+     * @see <a href="https://www.campaignmonitor.com/api/lists/#unconfirmed-subscribers" target="_blank">
      * Getting active subscribers</a>
      */
     public PagedResult<Subscriber> unconfirmed() throws CreateSendException {
@@ -293,7 +293,7 @@ public class Lists extends CreateSendBase {
      * @param includeTrackingPreference To include subscriber consent to track value in the results.
      * @return The paged subscribers returned by the api call.
      * @throws CreateSendException Thrown when the API responds with a HTTP Status >= 400
-     * @see <a href="http://www.campaignmonitor.com/api/lists/#unconfirmed_subscribers" target="_blank">
+     * @see <a href="https://www.campaignmonitor.com/api/lists/#unconfirmed-subscribers" target="_blank">
      * Getting active subscribers</a>
      */
     public PagedResult<Subscriber> unconfirmed(boolean includeTrackingPreference) throws CreateSendException {
@@ -308,7 +308,7 @@ public class Lists extends CreateSendBase {
      * @param orderDirection The direction to order the results by. Use <code>null</code> for the default.
      * @return The paged subscribers returned by the api call.
      * @throws CreateSendException Thrown when the API responds with a HTTP Status >= 400
-     * @see <a href="http://www.campaignmonitor.com/api/lists/#unconfirmed_subscribers" target="_blank">
+     * @see <a href="https://www.campaignmonitor.com/api/lists/#unconfirmed-subscribers" target="_blank">
      * Getting active subscribers</a>
      */
     public PagedResult<Subscriber> unconfirmed(Integer page, Integer pageSize,
@@ -325,7 +325,7 @@ public class Lists extends CreateSendBase {
      * @param includeTrackingPreference To include subscriber consent to track value in the results.
      * @return The paged subscribers returned by the api call.
      * @throws CreateSendException Thrown when the API responds with a HTTP Status >= 400
-     * @see <a href="http://www.campaignmonitor.com/api/lists/#unconfirmed_subscribers" target="_blank">
+     * @see <a href="https://www.campaignmonitor.com/api/lists/#unconfirmed-subscribers" target="_blank">
      * Getting active subscribers</a>
      */
     public PagedResult<Subscriber> unconfirmed(Integer page, Integer pageSize, String orderField,
@@ -344,7 +344,7 @@ public class Lists extends CreateSendBase {
      * @param orderDirection The direction to order the results by. Use <code>null</code> for the default.
      * @return The paged subscribers returned by the api call.
      * @throws CreateSendException Thrown when the API responds with a HTTP Status >= 400
-     * @see <a href="http://www.campaignmonitor.com/api/lists/#unconfirmed_subscribers" target="_blank">
+     * @see <a href="https://www.campaignmonitor.com/api/lists/#unconfirmed-subscribers" target="_blank">
      * Getting active subscribers</a>
      */
     public PagedResult<Subscriber> unconfirmed(Date subscribedFrom, Integer page, Integer pageSize,
@@ -365,7 +365,7 @@ public class Lists extends CreateSendBase {
      * @param includeTrackingPreference To include subscriber consent to track value in the results.
      * @return The paged subscribers returned by the api call.
      * @throws CreateSendException Thrown when the API responds with a HTTP Status >= 400
-     * @see <a href="http://www.campaignmonitor.com/api/lists/#unconfirmed_subscribers" target="_blank">
+     * @see <a href="https://www.campaignmonitor.com/api/lists/#unconfirmed-subscribers" target="_blank">
      * Getting active subscribers</a>
      */
     public PagedResult<Subscriber> unconfirmed(Date subscribedFrom, Integer page, Integer pageSize,
@@ -388,7 +388,7 @@ public class Lists extends CreateSendBase {
      * Gets a paged collection of unsubscribed subscribers who have unsubscribed from the list.
      * @return The paged subscribers returned by the api call.
      * @throws CreateSendException Thrown when the API responds with a HTTP Status >= 400
-     * @see <a href="http://www.campaignmonitor.com/api/lists/#unsubscribed_subscribers" target="_blank">
+     * @see <a href="https://www.campaignmonitor.com/api/lists/#unsubscribed-subscribers" target="_blank">
      * Getting unsubscribed subscribers</a>
      */
     public PagedResult<Subscriber> unsubscribed() throws CreateSendException {
@@ -400,7 +400,7 @@ public class Lists extends CreateSendBase {
      * @param includeTrackingPreference To include subscriber consent to track value in the results.
      * @return The paged subscribers returned by the api call.
      * @throws CreateSendException Thrown when the API responds with a HTTP Status >= 400
-     * @see <a href="http://www.campaignmonitor.com/api/lists/#unsubscribed_subscribers" target="_blank">
+     * @see <a href="https://www.campaignmonitor.com/api/lists/#unsubscribed-subscribers" target="_blank">
      * Getting unsubscribed subscribers</a>
      */
     public PagedResult<Subscriber> unsubscribed(boolean includeTrackingPreference) throws CreateSendException {
@@ -416,7 +416,7 @@ public class Lists extends CreateSendBase {
      * @param orderDirection The direction to order the results by. Use <code>null</code> for the default.
      * @return The paged subscribers returned by the api call.
      * @throws CreateSendException Thrown when the API responds with a HTTP Status >= 400
-     * @see <a href="http://www.campaignmonitor.com/api/lists/#unsubscribed_subscribers" target="_blank">
+     * @see <a href="https://www.campaignmonitor.com/api/lists/#unsubscribed-subscribers" target="_blank">
      * Getting unsubscribed subscribers</a>
      */
     public PagedResult<Subscriber> unsubscribed(Integer page, Integer pageSize,
@@ -433,7 +433,7 @@ public class Lists extends CreateSendBase {
      * @param includeTrackingPreference To include subscriber consent to track value in the results.
      * @return The paged subscribers returned by the api call.
      * @throws CreateSendException Thrown when the API responds with a HTTP Status >= 400
-     * @see <a href="http://www.campaignmonitor.com/api/lists/#unsubscribed_subscribers" target="_blank">
+     * @see <a href="https://www.campaignmonitor.com/api/lists/#unsubscribed-subscribers" target="_blank">
      * Getting unsubscribed subscribers</a>
      */
     public PagedResult<Subscriber> unsubscribed(Integer page, Integer pageSize,
@@ -451,7 +451,7 @@ public class Lists extends CreateSendBase {
      * @param orderDirection The direction to order the results by. Use <code>null</code> for the default.
      * @return The paged subscribers returned by the api call.
      * @throws CreateSendException Thrown when the API responds with a HTTP Status >= 400
-     * @see <a href="http://www.campaignmonitor.com/api/lists/#unsubscribed_subscribers" target="_blank">
+     * @see <a href="https://www.campaignmonitor.com/api/lists/#unsubscribed-subscribers" target="_blank">
      * Getting unsubscribed subscribers</a>
      */
     public PagedResult<Subscriber> unsubscribed(Date subscribedFrom, Integer page,
@@ -471,7 +471,7 @@ public class Lists extends CreateSendBase {
      * @param includeTrackingPreference To include subscriber consent to track value in the results.
      * @return The paged subscribers returned by the api call.
      * @throws CreateSendException Thrown when the API responds with a HTTP Status >= 400
-     * @see <a href="http://www.campaignmonitor.com/api/lists/#unsubscribed_subscribers" target="_blank">
+     * @see <a href="https://www.campaignmonitor.com/api/lists/#unsubscribed-subscribers" target="_blank">
      * Getting unsubscribed subscribers</a>
      */
     public PagedResult<Subscriber> unsubscribed(Date subscribedFrom, Integer page, Integer pageSize,
@@ -495,7 +495,7 @@ public class Lists extends CreateSendBase {
      * Gets a paged collection of subscribers who have been deleted from the list.
      * @return The paged subscribers returned by the api call.
      * @throws CreateSendException Thrown when the API responds with a HTTP Status >= 400
-     * @see <a href="http://www.campaignmonitor.com/api/lists/#deleted_subscribers" target="_blank">
+     * @see <a href="https://www.campaignmonitor.com/api/lists/#deleted-subscribers" target="_blank">
      * Getting deleted subscribers</a>
      */
     public PagedResult<Subscriber> deleted() throws CreateSendException {
@@ -507,7 +507,7 @@ public class Lists extends CreateSendBase {
      * @param includeTrackingPreference To include subscriber consent to track value in the results.
      * @return The paged subscribers returned by the api call.
      * @throws CreateSendException Thrown when the API responds with a HTTP Status >= 400
-     * @see <a href="http://www.campaignmonitor.com/api/lists/#deleted_subscribers" target="_blank">
+     * @see <a href="https://www.campaignmonitor.com/api/lists/#deleted-subscribers" target="_blank">
      * Getting deleted subscribers</a>
      */
     public PagedResult<Subscriber> deleted(boolean includeTrackingPreference) throws CreateSendException {
@@ -522,7 +522,7 @@ public class Lists extends CreateSendBase {
      * @param orderDirection The direction to order the results by. Use <code>null</code> for the default.
      * @return The paged subscribers returned by the api call.
      * @throws CreateSendException Thrown when the API responds with a HTTP Status >= 400
-     * @see <a href="http://www.campaignmonitor.com/api/lists/#deleted_subscribers" target="_blank">
+     * @see <a href="https://www.campaignmonitor.com/api/lists/#deleted-subscribers" target="_blank">
      * Getting deleted subscribers</a>
      */
     public PagedResult<Subscriber> deleted(Integer page, Integer pageSize, String orderField,
@@ -539,7 +539,7 @@ public class Lists extends CreateSendBase {
      * @param includeTrackingPreference To include subscriber consent to track value in the results.
      * @return The paged subscribers returned by the api call.
      * @throws CreateSendException Thrown when the API responds with a HTTP Status >= 400
-     * @see <a href="http://www.campaignmonitor.com/api/lists/#deleted_subscribers" target="_blank">
+     * @see <a href="https://www.campaignmonitor.com/api/lists/#deleted-subscribers" target="_blank">
      * Getting deleted subscribers</a>
      */
     public PagedResult<Subscriber> deleted(Integer page, Integer pageSize, String orderField,
@@ -557,7 +557,7 @@ public class Lists extends CreateSendBase {
      * @param orderDirection The direction to order the results by. Use <code>null</code> for the default.
      * @return The paged subscribers returned by the api call.
      * @throws CreateSendException Thrown when the API responds with a HTTP Status >= 400
-     * @see <a href="http://www.campaignmonitor.com/api/lists/#deleted_subscribers" target="_blank">
+     * @see <a href="https://www.campaignmonitor.com/api/lists/#deleted-subscribers" target="_blank">
      * Getting deleted subscribers</a>
      */
     public PagedResult<Subscriber> deleted(Date subscribedFrom,Integer page, Integer pageSize,
@@ -577,7 +577,7 @@ public class Lists extends CreateSendBase {
      * @param includeTrackingPreference To include subscriber consent to track value in the results.
      * @return The paged subscribers returned by the api call.
      * @throws CreateSendException Thrown when the API responds with a HTTP Status >= 400
-     * @see <a href="http://www.campaignmonitor.com/api/lists/#deleted_subscribers" target="_blank">
+     * @see <a href="https://www.campaignmonitor.com/api/lists/#deleted-subscribers" target="_blank">
      * Getting deleted subscribers</a>
      */
     public PagedResult<Subscriber> deleted(Date subscribedFrom, Integer page, Integer pageSize,
@@ -600,7 +600,7 @@ public class Lists extends CreateSendBase {
      * Gets a paged collection of bounced subscribers who have bounced out of the list.
      * @return The paged subscribers returned by the api call.
      * @throws CreateSendException Thrown when the API responds with a HTTP Status >= 400
-     * @see <a href="http://www.campaignmonitor.com/api/lists/#bounced_subscribers" target="_blank">
+     * @see <a href="https://www.campaignmonitor.com/api/lists/#bounced-subscribers" target="_blank">
      * Getting bounced subscribers</a>
      */
     public PagedResult<Subscriber> bounced() throws CreateSendException {
@@ -612,7 +612,7 @@ public class Lists extends CreateSendBase {
      * @param includeTrackingPreference To include subscriber consent to track value in the results.
      * @return The paged subscribers returned by the api call.
      * @throws CreateSendException Thrown when the API responds with a HTTP Status >= 400
-     * @see <a href="http://www.campaignmonitor.com/api/lists/#bounced_subscribers" target="_blank">
+     * @see <a href="https://www.campaignmonitor.com/api/lists/#bounced-subscribers" target="_blank">
      * Getting bounced subscribers</a>
      */
     public PagedResult<Subscriber> bounced(boolean includeTrackingPreference) throws CreateSendException {
@@ -627,7 +627,7 @@ public class Lists extends CreateSendBase {
      * @param orderDirection The direction to order the results by. Use <code>null</code> for the default.
      * @return The paged subscribers returned by the api call.
      * @throws CreateSendException Thrown when the API responds with a HTTP Status >= 400
-     * @see <a href="http://www.campaignmonitor.com/api/lists/#bounced_subscribers" target="_blank">
+     * @see <a href="https://www.campaignmonitor.com/api/lists/#bounced-subscribers" target="_blank">
      * Getting bounced subscribers</a>
      */
     public PagedResult<Subscriber> bounced(Integer page, Integer pageSize,
@@ -644,7 +644,7 @@ public class Lists extends CreateSendBase {
      * @param includeTrackingPreference To include subscriber consent to track value in the results.
      * @return The paged subscribers returned by the api call.
      * @throws CreateSendException Thrown when the API responds with a HTTP Status >= 400
-     * @see <a href="http://www.campaignmonitor.com/api/lists/#bounced_subscribers" target="_blank">
+     * @see <a href="https://www.campaignmonitor.com/api/lists/#bounced-subscribers" target="_blank">
      * Getting bounced subscribers</a>
      */
     public PagedResult<Subscriber> bounced(Integer page, Integer pageSize, String orderField,
@@ -662,7 +662,7 @@ public class Lists extends CreateSendBase {
      * @param orderDirection The direction to order the results by. Use <code>null</code> for the default.
      * @return The paged subscribers returned by the api call.
      * @throws CreateSendException Thrown when the API responds with a HTTP Status >= 400
-     * @see <a href="http://www.campaignmonitor.com/api/lists/#bounced_subscribers" target="_blank">
+     * @see <a href="https://www.campaignmonitor.com/api/lists/#bounced-subscribers" target="_blank">
      * Getting bounced subscribers</a>
      */
     public PagedResult<Subscriber> bounced(Date subscribedFrom, Integer page,
@@ -682,7 +682,7 @@ public class Lists extends CreateSendBase {
      * @param includeTrackingPreference To include subscriber consent to track value in the results.
      * @return The paged subscribers returned by the api call.
      * @throws CreateSendException Thrown when the API responds with a HTTP Status >= 400
-     * @see <a href="http://www.campaignmonitor.com/api/lists/#bounced_subscribers" target="_blank">
+     * @see <a href="https://www.campaignmonitor.com/api/lists/#bounced-subscribers" target="_blank">
      * Getting bounced subscribers</a>
      */
     public PagedResult<Subscriber> bounced(Date subscribedFrom, Integer page, Integer pageSize,
@@ -706,7 +706,7 @@ public class Lists extends CreateSendBase {
      * @param customField The custom field options
      * @return The Key of the newly created custom field
      * @throws CreateSendException Thrown when the API responds with HTTP Status >= 400
-     * @see <a href="http://www.campaignmonitor.com/api/lists/#creating_a_custom_field" target="_blank">
+     * @see <a href="https://www.campaignmonitor.com/api/lists/#creating-custom-field" target="_blank">
      * Creating a custom field</a>
      */
     public String createCustomField(CustomFieldForCreate customField) throws CreateSendException {
@@ -719,7 +719,7 @@ public class Lists extends CreateSendBase {
      * @param customField The custom field options
      * @return The Key of the updated custom field
      * @throws CreateSendException Thrown when the API responds with HTTP Status >= 400
-     * @see <a href="http://www.campaignmonitor.com/api/lists/#updating_a_custom_field" target="_blank">
+     * @see <a href="https://www.campaignmonitor.com/api/lists/#updating-custom-field" target="_blank">
      * Creating a custom field</a>
      */
     public String updateCustomField(String fieldKey, CustomFieldForUpdate customField)
@@ -732,7 +732,7 @@ public class Lists extends CreateSendBase {
      * @param fieldKey The <em>Key</em> of the custom field to update. This must be surrounded by [].
      * @param options The new options to use for the field. 
      * @throws CreateSendException Raised when the API responds with HTTP Status >= 400
-     * @see <a href="http://www.campaignmonitor.com/api/lists/#updating_custom_field_options" target="_blank">
+     * @see <a href="https://www.campaignmonitor.com/api/lists/#updating-custom-field-options" target="_blank">
      * Updating custom field options</a>
      */
     public void updateCustomFieldOptions(String fieldKey, UpdateFieldOptions options)
@@ -744,7 +744,7 @@ public class Lists extends CreateSendBase {
      * Deletes the custom field with the specified key
      * @param fieldKey The <em>Key</em> of the custom field to delete. This must be surrounded by [].
      * @throws CreateSendException Thrown when the API responds with HTTP Status >= 400
-     * @see <a href="http://www.campaignmonitor.com/api/lists/#deleting_a_custom_field" target="_blank">
+     * @see <a href="https://www.campaignmonitor.com/api/lists/#deleting-custom-field" target="_blank">
      * Deleting a custom field</a>
      */
     public void deleteCustomField(String fieldKey) throws CreateSendException {
@@ -755,7 +755,7 @@ public class Lists extends CreateSendBase {
      * Gets all webhooks which have been attached to events on the specified list
      * @return The webhooks which have been attached to events for the specified list
      * @throws CreateSendException Thrown when the API responds with HTTP Status >= 400
-     * @see <a href="http://www.campaignmonitor.com/api/lists/#getting_list_webhooks" target="_blank">
+     * @see <a href="https://www.campaignmonitor.com/api/lists/#list-webhooks" target="_blank">
      * Getting list webhooks</a>
      */
     public Webhook[] webhooks() throws CreateSendException {
@@ -767,7 +767,7 @@ public class Lists extends CreateSendBase {
      * @param webhook The webhook details
      * @return The ID of the newly created webhook
      * @throws CreateSendException Thrown when the API responds with HTTP Status >= 400
-     * @see <a href="http://www.campaignmonitor.com/api/lists/#creating_a_webhook" target="_blank">
+     * @see <a href="https://www.campaignmonitor.com/api/lists/#creating-a-webhook" target="_blank">
      * Creating a webhook</a>
      */
     public String createWebhook(Webhook webhook) throws CreateSendException {
@@ -778,7 +778,7 @@ public class Lists extends CreateSendBase {
      * Tests the specified webhook
      * @param webhookID The ID of the webhook
      * @throws CreateSendException Thrown when the API responds with HTTP Status >= 400. I.e the test fails
-     * @see <a href="http://www.campaignmonitor.com/api/lists/#testing_a_webhook" target="_blank">
+     * @see <a href="https://www.campaignmonitor.com/api/lists/#testing-a-webhook" target="_blank">
      * Testing a webhook</a>
      */
     public void testWebhook(String webhookID) throws CreateSendException {
@@ -790,7 +790,7 @@ public class Lists extends CreateSendBase {
      * Deletes the specified webhook
      * @param webhookID The ID of the webhook to delete
      * @throws CreateSendException Raised when the API responds with HTTP Status >= 400
-     * @see <a href="http://www.campaignmonitor.com/api/lists/#deleting_a_webhook" target="_blank">
+     * @see <a href="https://www.campaignmonitor.com/api/lists/#deleting-a-webhook" target="_blank">
      * Deleting a webhook</a>
      */
     public void deleteWebhook(String webhookID) throws CreateSendException {
@@ -801,7 +801,7 @@ public class Lists extends CreateSendBase {
      * Activates the specified webhook.
      * @param webhookID The ID of the webhook to activate
      * @throws CreateSendException Thrown when the API responds with HTTP Status >= 400
-     * @see <a href="http://www.campaignmonitor.com/api/lists/#activating_a_webhook" target="_blank">
+     * @see <a href="https://www.campaignmonitor.com/api/lists/#activating-a-webhook" target="_blank">
      * Activating a webhook</a>
      */
     public void activateWebhook(String webhookID) throws CreateSendException {
@@ -812,7 +812,7 @@ public class Lists extends CreateSendBase {
      * Deactivates the specified webhook.
      * @param webhookID The ID of the webhook to deactivate
      * @throws CreateSendException Thrown when the API responds with HTTP Status >= 400
-     * @see <a href="http://www.campaignmonitor.com/api/lists/#deactivating_a_webhook" target="_blank">
+     * @see <a href="https://www.campaignmonitor.com/api/lists/#deactivating-a-webhook" target="_blank">
      * Activating a webhook</a>
      */
     public void deactivateWebhook(String webhookID) throws CreateSendException {

--- a/src/com/createsend/Segments.java
+++ b/src/com/createsend/Segments.java
@@ -88,7 +88,7 @@ public class Segments extends CreateSendBase {
      * @param segment The segment details
      * @return The ID of the newly created segment
      * @throws CreateSendException Thrown when the API responds with HTTP Status >= 400
-     * @see <a href="http://www.campaignmonitor.com/api/segments/#creating_a_segment" target="blank">
+     * @see <a href="https://www.campaignmonitor.com/api/segments/#creating-a-segment" target="blank">
      * Creating a segment</a>
      */
     public String create(String listID, Segment segment) throws CreateSendException {
@@ -102,7 +102,7 @@ public class Segments extends CreateSendBase {
      * @param segment The details of the segment to update. 
      *     The <code>SegmentID</code> field of this object must be populated
      * @throws CreateSendException Thrown when the API responds with HTTP Status >= 400
-     * @see <a href="http://www.campaignmonitor.com/api/segments/#updating_a_segment" target="blank">
+     * @see <a href="https://www.campaignmonitor.com/api/segments/#updating-a-segment" target="blank">
      * Updating a segment</a>
      */
     public void update(Segment segment) throws CreateSendException {
@@ -114,7 +114,7 @@ public class Segments extends CreateSendBase {
      * Adds a new rule to an existing list segment
      * @param ruleGroup The rule group specification
      * @throws CreateSendException Raised when the API responds with HTTP Status >= 400
-     * @see <a href="http://www.campaignmonitor.com/api/segments/#adding_a_segment_rule" target="_blank">
+     * @see <a href="https://www.campaignmonitor.com/api/segments/#adding-segment-rulegroup" target="_blank">
      * Adding a segment rule</a>
      */
     public void addRuleGroup(RuleGroup ruleGroup) throws CreateSendException {
@@ -127,7 +127,7 @@ public class Segments extends CreateSendBase {
      * active subscribers.
      * @return The details of the specified segment.
      * @throws CreateSendException Raised when the API responds with HTTP Status >= 400
-     * @see <a href="http://www.campaignmonitor.com/api/segments/#getting_a_segment" target="_blank">
+     * @see <a href="https://www.campaignmonitor.com/api/segments/#getting-segments-details" target="_blank">
      * Getting a segment</a>
      */
     public Segment details() throws CreateSendException {
@@ -136,7 +136,7 @@ public class Segments extends CreateSendBase {
 
     /**
      * Gets a paged collection of active subscribers within the specified segment.
-     * @return The paged subscribers returned by the api call.
+     * @return The paged subscribers returned by the API call.
      * @throws CreateSendException Thrown when the API responds with a HTTP Status >= 400
      * @see <a href="http://www.campaignmonitor.com/api/segments/#getting-active-subscribers" target="_blank">
      * Getting active subscribers</a>
@@ -148,7 +148,7 @@ public class Segments extends CreateSendBase {
     /**
      * Gets a paged collection of active subscribers within the specified segment.
      * @param includeTrackingPreference To include subscriber consent to track value in the results.
-     * @return The paged subscribers returned by the api call.
+     * @return The paged subscribers returned by the API call.
      * @throws CreateSendException Thrown when the API responds with a HTTP Status >= 400
      * @see <a href="http://www.campaignmonitor.com/api/segments/#getting-active-subscribers" target="_blank">
      * Getting active subscribers</a>
@@ -163,7 +163,7 @@ public class Segments extends CreateSendBase {
      * @param pageSize The number of records to get on the current page. Use <code>null</code> for the default.
      * @param orderField The field used to order the results by. Use <code>null</code> for the default.
      * @param orderDirection The direction to order the results by. Use <code>null</code> for the default.
-     * @return The paged subscribers returned by the api call.
+     * @return The paged subscribers returned by the API call.
      * @throws CreateSendException Thrown when the API responds with a HTTP Status >= 400
      * @see <a href="http://www.campaignmonitor.com/api/segments/#getting-active-subscribers" target="_blank">
      * Getting active subscribers</a>
@@ -180,7 +180,7 @@ public class Segments extends CreateSendBase {
      * @param orderField The field used to order the results by. Use <code>null</code> for the default.
      * @param orderDirection The direction to order the results by. Use <code>null</code> for the default.
      * @param includeTrackingPreference To include subscriber consent to track value in the results.
-     * @return The paged subscribers returned by the api call.
+     * @return The paged subscribers returned by the API call.
      * @throws CreateSendException Thrown when the API responds with a HTTP Status >= 400
      * @see <a href="http://www.campaignmonitor.com/api/segments/#getting-active-subscribers" target="_blank">
      * Getting active subscribers</a>
@@ -199,7 +199,7 @@ public class Segments extends CreateSendBase {
      * @param pageSize The number of records to get on the current page. Use <code>null</code> for the default.
      * @param orderField The field used to order the results by. Use <code>null</code> for the default.
      * @param orderDirection The direction to order the results by. Use <code>null</code> for the default.
-     * @return The paged subscribers returned by the api call.
+     * @return The paged subscribers returned by the API call.
      * @throws CreateSendException Thrown when the API responds with a HTTP Status >= 400
      * @see <a href="http://www.campaignmonitor.com/api/segments/#getting-active-subscribers" target="_blank">
      * Getting active subscribers</a>
@@ -220,7 +220,7 @@ public class Segments extends CreateSendBase {
      * @param orderField The field used to order the results by. Use <code>null</code> for the default.
      * @param orderDirection The direction to order the results by. Use <code>null</code> for the default.
      * @param includeTrackingPreference To include subscriber consent to track value in the results.
-     * @return The paged subscribers returned by the api call.
+     * @return The paged subscribers returned by the API call.
      * @throws CreateSendException Thrown when the API responds with a HTTP Status >= 400
      * @see <a href="http://www.campaignmonitor.com/api/segments/#getting-active-subscribers" target="_blank">
      * Getting active subscribers</a>
@@ -244,7 +244,7 @@ public class Segments extends CreateSendBase {
     /**
      * Deletes the specified segment.
      * @throws CreateSendException Raised when the API responds with HTTP Status >= 400
-     * @see <a href="http://www.campaignmonitor.com/api/segments/#deleting_a_segment" target="_blank">
+     * @see <a href="https://www.campaignmonitor.com/api/segments/#deleting-a-segment" target="_blank">
      * Deleting a segment</a>
      */
     public void delete() throws CreateSendException {
@@ -254,7 +254,7 @@ public class Segments extends CreateSendBase {
     /**
      * Deletes <em>all</em> rules from the specifed segment
      * @throws CreateSendException Raised when the API responds with HTTP Status >= 400
-     * @see <a href="http://www.campaignmonitor.com/api/segments/#deleting_segment_rules" target="_blank">
+     * @see <a href="https://www.campaignmonitor.com/api/segments/#deleting-segments-rules" target="_blank">
      * Deleting a segments rules</a>
      */
     public void deleteRules() throws CreateSendException {

--- a/src/com/createsend/Segments.java
+++ b/src/com/createsend/Segments.java
@@ -138,11 +138,23 @@ public class Segments extends CreateSendBase {
      * Gets a paged collection of active subscribers within the specified segment.
      * @return The paged subscribers returned by the api call.
      * @throws CreateSendException Thrown when the API responds with a HTTP Status >= 400
-     * @see <a href="http://www.campaignmonitor.com/api/segments/#getting_segment_subs" target="_blank">
+     * @see <a href="http://www.campaignmonitor.com/api/segments/#getting-active-subscribers" target="_blank">
      * Getting active subscribers</a>
      */
     public PagedResult<Subscriber> active() throws CreateSendException {
-    	return active(1, 1000, "email", "asc");
+    	return active(1, 1000, "email", "asc", false);
+    }
+
+    /**
+     * Gets a paged collection of active subscribers within the specified segment.
+     * @param includeTrackingPreference To include subscriber consent to track value in the results.
+     * @return The paged subscribers returned by the api call.
+     * @throws CreateSendException Thrown when the API responds with a HTTP Status >= 400
+     * @see <a href="http://www.campaignmonitor.com/api/segments/#getting-active-subscribers" target="_blank">
+     * Getting active subscribers</a>
+     */
+    public PagedResult<Subscriber> active(boolean includeTrackingPreference) throws CreateSendException {
+        return active(1, 1000, "email", "asc", includeTrackingPreference);
     }
 
     /**
@@ -153,12 +165,29 @@ public class Segments extends CreateSendBase {
      * @param orderDirection The direction to order the results by. Use <code>null</code> for the default.
      * @return The paged subscribers returned by the api call.
      * @throws CreateSendException Thrown when the API responds with a HTTP Status >= 400
-     * @see <a href="http://www.campaignmonitor.com/api/segments/#getting_segment_subs" target="_blank">
+     * @see <a href="http://www.campaignmonitor.com/api/segments/#getting-active-subscribers" target="_blank">
      * Getting active subscribers</a>
      */
-    public PagedResult<Subscriber> active(
-            Integer page, Integer pageSize, String orderField, String orderDirection) throws CreateSendException {
-    	return active("", page, pageSize, orderField, orderDirection);
+    public PagedResult<Subscriber> active(Integer page, Integer pageSize,
+        String orderField, String orderDirection) throws CreateSendException {
+    	return active("", page, pageSize, orderField, orderDirection, false);
+    }
+
+    /**
+     * Gets a paged collection of active subscribers within the specified segment.
+     * @param page The page number or results to get. Use <code>null</code> for the default (page=1)
+     * @param pageSize The number of records to get on the current page. Use <code>null</code> for the default.
+     * @param orderField The field used to order the results by. Use <code>null</code> for the default.
+     * @param orderDirection The direction to order the results by. Use <code>null</code> for the default.
+     * @param includeTrackingPreference To include subscriber consent to track value in the results.
+     * @return The paged subscribers returned by the api call.
+     * @throws CreateSendException Thrown when the API responds with a HTTP Status >= 400
+     * @see <a href="http://www.campaignmonitor.com/api/segments/#getting-active-subscribers" target="_blank">
+     * Getting active subscribers</a>
+     */
+    public PagedResult<Subscriber> active(Integer page, Integer pageSize, String orderField,
+        String orderDirection, boolean includeTrackingPreference) throws CreateSendException {
+        return active("", page, pageSize, orderField, orderDirection, includeTrackingPreference);
     }
 
     /**
@@ -172,20 +201,42 @@ public class Segments extends CreateSendBase {
      * @param orderDirection The direction to order the results by. Use <code>null</code> for the default.
      * @return The paged subscribers returned by the api call.
      * @throws CreateSendException Thrown when the API responds with a HTTP Status >= 400
-     * @see <a href="http://www.campaignmonitor.com/api/segments/#getting_segment_subs" target="_blank">
+     * @see <a href="http://www.campaignmonitor.com/api/segments/#getting-active-subscribers" target="_blank">
      * Getting active subscribers</a>
      */
-    public PagedResult<Subscriber> active(Date subscribedFrom,
-            Integer page, Integer pageSize, String orderField, String orderDirection) throws CreateSendException {
+    public PagedResult<Subscriber> active(Date subscribedFrom, Integer page, Integer pageSize,
+        String orderField, String orderDirection) throws CreateSendException {
     	return active(JsonProvider.ApiDateFormat.format(subscribedFrom),
-    			page, pageSize, orderField, orderDirection);
+    			page, pageSize, orderField, orderDirection, false);
     }
 
-    private PagedResult<Subscriber> active(String subscribedFrom,
-        Integer page, Integer pageSize, String orderField, String orderDirection) throws CreateSendException {
+    /**
+     * Gets a paged collection of active subscribers within the specified segment
+     * since the provided date.
+     * @param subscribedFrom The API will only return subscribers who became active on or after this date.
+     *     This field is required
+     * @param page The page number or results to get. Use <code>null</code> for the default (page=1)
+     * @param pageSize The number of records to get on the current page. Use <code>null</code> for the default.
+     * @param orderField The field used to order the results by. Use <code>null</code> for the default.
+     * @param orderDirection The direction to order the results by. Use <code>null</code> for the default.
+     * @param includeTrackingPreference To include subscriber consent to track value in the results.
+     * @return The paged subscribers returned by the api call.
+     * @throws CreateSendException Thrown when the API responds with a HTTP Status >= 400
+     * @see <a href="http://www.campaignmonitor.com/api/segments/#getting-active-subscribers" target="_blank">
+     * Getting active subscribers</a>
+     */
+    public PagedResult<Subscriber> active(Date subscribedFrom, Integer page, Integer pageSize,
+        String orderField, String orderDirection, boolean includeTrackingPreference) throws CreateSendException {
+        return active(JsonProvider.ApiDateFormat.format(subscribedFrom),
+            page, pageSize, orderField, orderDirection, includeTrackingPreference);
+    }
+
+    private PagedResult<Subscriber> active(String subscribedFrom, Integer page, Integer pageSize,
+        String orderField, String orderDirection, boolean includeTrackingPreference) throws CreateSendException {
         MultivaluedMap<String, String> queryString = new MultivaluedMapImpl(); 
         queryString.add("date", subscribedFrom);
-        
+        queryString.add("includetrackingpreference", String.valueOf(includeTrackingPreference));
+
         return jerseyClient.getPagedResult(page, pageSize, orderField, orderDirection,
             queryString, "segments", segmentID, "active.json");
     }

--- a/src/com/createsend/SmartEmail.java
+++ b/src/com/createsend/SmartEmail.java
@@ -35,7 +35,7 @@ import javax.ws.rs.core.MultivaluedMap;
 import java.util.UUID;
 
 /**
- * Provides methods for accessing all <a href="http://www.campaignmonitor.com/api/transactional/smartEmail/" target="_blank">
+ * Provides methods for accessing all <a href="https://www.campaignmonitor.com/api/transactional/" target="_blank">
  * Transactional Smart Email</a> resources in the Campaign Monitor API
  */
 public class SmartEmail extends CreateSendBase {

--- a/src/com/createsend/Subscribers.java
+++ b/src/com/createsend/Subscribers.java
@@ -106,9 +106,23 @@ public class Subscribers extends CreateSendBase {
      * Getting subscriber details</a>
      */
     public Subscriber details(String emailAddress) throws CreateSendException {
+        return details(emailAddress, false);
+    }
+
+    /**
+     * Gets the details for the subscriber with the given email address in the specified list
+     * @param emailAddress The email address to get the subscriber details for
+     * @param includeTrackingPreference To include subscriber consent to track value.
+     * @return The details of the subscriber
+     * @throws CreateSendException Thrown when the API responds with HTTP Status >= 400
+     * @see <a href="http://www.campaignmonitor.com/api/subscribers/#getting_subscriber_details" target="_blank">
+     * Getting subscriber details</a>
+     */
+    public Subscriber details(String emailAddress, boolean includeTrackingPreference) throws CreateSendException {
         MultivaluedMap<String, String> queryString = new MultivaluedMapImpl();
         queryString.add("email", emailAddress);
-        
+        queryString.add("includetrackingpreference", String.valueOf(includeTrackingPreference));
+
         return jerseyClient.get(Subscriber.class, queryString, "subscribers", listID + ".json");
     }
     

--- a/src/com/createsend/Subscribers.java
+++ b/src/com/createsend/Subscribers.java
@@ -75,7 +75,7 @@ public class Subscribers extends CreateSendBase {
      * @param subscriber The subscriber to add to the list
      * @return The email addresss of the newly added subscriber
      * @throws CreateSendException Thrown when the API responds with HTTP Status >= 400
-     * @see <a href="http://www.campaignmonitor.com/api/subscribers/#adding_a_subscriber" target="_blank">
+     * @see <a href="https://www.campaignmonitor.com/api/subscribers/#adding-a-subscriber" target="_blank">
      * Adding a subscriber</a>
      */
     public String add(SubscriberToAdd subscriber) throws CreateSendException {
@@ -89,7 +89,7 @@ public class Subscribers extends CreateSendBase {
      * This will detail how many of the subscribers were new, already subscribed to the list
      * or duplicated in the submission     
      * @throws CreateSendException Thrown when the API responds with HTTP Status >= 400
-     * @see <a href="http://www.campaignmonitor.com/api/subscribers/#importing_subscribers" target="_blank">
+     * @see <a href="https://www.campaignmonitor.com/api/subscribers/#importing-many-subscribers" target="_blank">
      * Importing subscribers</a>
      */
     public ImportResult addMany(SubscribersToAdd subscribers) throws CreateSendException {
@@ -102,7 +102,7 @@ public class Subscribers extends CreateSendBase {
      * @param emailAddress The email address to get the subscriber details for
      * @return The details of the subscriber
      * @throws CreateSendException Thrown when the API responds with HTTP Status >= 400
-     * @see <a href="http://www.campaignmonitor.com/api/subscribers/#getting_subscriber_details" target="_blank">
+     * @see <a href="https://www.campaignmonitor.com/api/subscribers/#getting-subscribers-details" target="_blank">
      * Getting subscriber details</a>
      */
     public Subscriber details(String emailAddress) throws CreateSendException {
@@ -115,7 +115,7 @@ public class Subscribers extends CreateSendBase {
      * @param includeTrackingPreference To include subscriber consent to track value.
      * @return The details of the subscriber
      * @throws CreateSendException Thrown when the API responds with HTTP Status >= 400
-     * @see <a href="http://www.campaignmonitor.com/api/subscribers/#getting_subscriber_details" target="_blank">
+     * @see <a href="https://www.campaignmonitor.com/api/subscribers/#getting-subscribers-details" target="_blank">
      * Getting subscriber details</a>
      */
     public Subscriber details(String emailAddress, boolean includeTrackingPreference) throws CreateSendException {
@@ -131,7 +131,7 @@ public class Subscribers extends CreateSendBase {
      * @param emailAddress The email address of the subscriber to get the history for
      * @return The complete history for the given subscriber
      * @throws CreateSendException Thrown when the API responds with HTTP Status >= 400
-     * @see <a href="http://www.campaignmonitor.com/api/subscribers/#getting_subscriber_history" target="_blank">
+     * @see <a href="https://www.campaignmonitor.com/api/subscribers/#getting-subscribers-history" target="_blank">
      * Getting subscriber history</a>
      */
     public HistoryItem[] history(String emailAddress) throws CreateSendException {
@@ -145,7 +145,7 @@ public class Subscribers extends CreateSendBase {
      * Unsubscribes the given email address from the specified list
      * @param emailAddress The email address to unsubscibe
      * @throws CreateSendException Thrown when the API responds with HTTP Status >= 400
-     * @see <a href="http://www.campaignmonitor.com/api/subscribers/#unsubscribing_a_subscriber" target="_blank">
+     * @see <a href="https://www.campaignmonitor.com/api/subscribers/#unsubscribing-a-subscriber" target="_blank">
      * Unsubscribing a subscriber</a>
      */
     public void unsubscribe(String emailAddress) throws CreateSendException {
@@ -157,7 +157,7 @@ public class Subscribers extends CreateSendBase {
      * Moves the given email address into the deleted list
      * @param emailAddress The email address to delete
      * @throws CreateSendException Thrown when the API responds with HTTP Status >= 400
-     * @see <a href="http://www.campaignmonitor.com/api/subscribers/#deleting_a_subscriber" target="_blank">
+     * @see <a href="https://www.campaignmonitor.com/api/subscribers/#deleting-a-subscriber" target="_blank">
      * Deleting a subscriber</a>
      */
     public void delete(String emailAddress) throws CreateSendException {
@@ -173,7 +173,7 @@ public class Subscribers extends CreateSendBase {
      * @param newDetails The new details for the subscriber. Any details included here will be used in the updated. 
      *     Any details omitted will not be changed.  
      * @throws CreateSendException Thrown when the API responds with HTTP Status >= 400
-     * @see <a href="http://www.campaignmonitor.com/api/subscribers/#updating_a_subscriber" target="_blank">
+     * @see <a href="https://www.campaignmonitor.com/api/subscribers/#updating-a-subscriber" target="_blank">
      * Updating a subscriber</a>
      */
     public void update(String originalEmailAddress, SubscriberToAdd newDetails) throws CreateSendException {

--- a/src/com/createsend/models/subscribers/ConsentToTrack.java
+++ b/src/com/createsend/models/subscribers/ConsentToTrack.java
@@ -1,0 +1,26 @@
+package com.createsend.models.subscribers;
+
+import org.codehaus.jackson.annotate.JsonCreator;
+
+public enum ConsentToTrack {
+  UNCHANGED("Unchanged"),
+  YES("Yes"),
+  NO("No");
+
+  private String value;
+
+  ConsentToTrack(String value) {
+    this.value = value;
+  }
+
+  @JsonCreator
+  public static ConsentToTrack forValue(String value) {
+    for (ConsentToTrack type : ConsentToTrack.values()) {
+      if (type.value.toLowerCase().equals(value.toLowerCase())) {
+        return type;
+      }
+    }
+
+    return null;
+  }
+}

--- a/src/com/createsend/models/subscribers/Subscriber.java
+++ b/src/com/createsend/models/subscribers/Subscriber.java
@@ -31,6 +31,7 @@ public class Subscriber {
     public String State; // TODO: Probably want to move this to an enum
     public CustomField[] CustomFields;
     public String ReadsEmailWith;
+    public ConsentToTrack ConsentToTrack;
     
     @Override
     public String toString() {

--- a/src/com/createsend/models/transactional/request/ClassicEmailRequest.java
+++ b/src/com/createsend/models/transactional/request/ClassicEmailRequest.java
@@ -21,6 +21,7 @@
  */
 package com.createsend.models.transactional.request;
 
+import com.createsend.models.subscribers.ConsentToTrack;
 import com.createsend.models.transactional.EmailContent;
 
 import java.util.ArrayList;
@@ -84,7 +85,7 @@ public class ClassicEmailRequest {
     /**
      * The ListID to add recipients to.
      */
-    private String addRecipientsToList;
+    private String addRecipientsToListID;
 
     /**
      * Should Css be automatically inlined.
@@ -101,12 +102,22 @@ public class ClassicEmailRequest {
      */
     private boolean trackClicks;
 
-    public ClassicEmailRequest(String to) {
+    /**
+     * The Consent to track value of the recipients
+     */
+    private ConsentToTrack consentToTrack;
+
+    public ClassicEmailRequest(String to, ConsentToTrack consentToTrack) {
         if (to == null || to.length() == 0) {
             throw new IllegalArgumentException("Must supply a TO address");
         }
 
+        if (consentToTrack == null) {
+            throw new IllegalArgumentException("Must supply a ConsentToTrack value");
+        }
+
         this.to.add(to);
+        this.consentToTrack = consentToTrack;
     }
 
     public void setSubject(String subject) {
@@ -169,12 +180,12 @@ public class ClassicEmailRequest {
         return attachments;
     }
 
-    public void setAddRecipientsToList(String addRecipientsToList) {
-        this.addRecipientsToList = addRecipientsToList;
+    public void setAddRecipientsToListID(String addRecipientsToListID) {
+        this.addRecipientsToListID = addRecipientsToListID;
     }
 
-    public String getAddRecipientsToList() {
-        return addRecipientsToList;
+    public String getAddRecipientsToListID() {
+        return addRecipientsToListID;
     }
 
     public String getFrom() {
@@ -199,5 +210,13 @@ public class ClassicEmailRequest {
 
     public void setGroup(String group) {
         this.group = group;
+    }
+
+    public ConsentToTrack getConsentToTrack() {
+        return consentToTrack;
+    }
+
+    public void setConsentToTrack(ConsentToTrack consentToTrack) {
+        this.consentToTrack = consentToTrack;
     }
 }

--- a/src/com/createsend/models/transactional/request/SmartEmailRequest.java
+++ b/src/com/createsend/models/transactional/request/SmartEmailRequest.java
@@ -21,6 +21,7 @@
  */
 package com.createsend.models.transactional.request;
 
+import com.createsend.models.subscribers.ConsentToTrack;
 import org.codehaus.jackson.annotate.JsonIgnore;
 import org.codehaus.jackson.annotate.JsonUnwrapped;
 
@@ -35,13 +36,14 @@ public class SmartEmailRequest {
     private List<Attachment> attachments = new ArrayList<>();
     private Map<String, String> data = new HashMap<>();
     private boolean addRecipientsToList;
+    private ConsentToTrack consentToTrack;
 
     /**
      * Creates a new SmartEmailRequest with mandatory values.
      * @param smartEmailId The SmartEmailID of the email to send.
      * @param to The recipient of the email.
      */
-    public SmartEmailRequest(UUID smartEmailId, String to) {
+    public SmartEmailRequest(UUID smartEmailId, String to, ConsentToTrack consentToTrack) {
         if (smartEmailId == null) {
             throw new IllegalArgumentException("Must supply a Smart Email ID");
         }
@@ -50,8 +52,13 @@ public class SmartEmailRequest {
             throw new IllegalArgumentException("Must supply a TO address");
         }
 
+        if (consentToTrack == null) {
+            throw new IllegalArgumentException("Must supply a ConsentToTrack value");
+        }
+
         this.smartEmailId = smartEmailId;
         this.to.add(to);
+        this.consentToTrack = consentToTrack;
     }
 
     /**
@@ -145,5 +152,21 @@ public class SmartEmailRequest {
      */
     public boolean isAddRecipientsToList() {
         return addRecipientsToList;
+    }
+
+    /**
+     *
+     * @return the consent to track value of the recipients
+     */
+    public ConsentToTrack getConsentToTrack() {
+        return consentToTrack;
+    }
+
+    /**
+     *
+     * @param consentToTrack consent to track value of the recipients
+     */
+    public void setConsentToTrack(ConsentToTrack consentToTrack) {
+        this.consentToTrack = consentToTrack;
     }
 }

--- a/src/com/createsend/util/config.properties
+++ b/src/com/createsend/util/config.properties
@@ -1,4 +1,4 @@
-createsend.version = 5.1.3
-createsend.endpoint = http://api.createsend.com/api/v3.1/
+createsend.version = 6.0.0
+createsend.endpoint = http://api.createsend.com/api/v3.2/
 createsend.oauthbaseuri = https://api.createsend.com/oauth/
 createsend.logging = false


### PR DESCRIPTION
## Description
See https://www.campaignmonitor.com/api/ for more info and further documentation on these changes. Please note, that the v3.2 API, contains breaking changes.

This library's release will be marked as 6.0.0. To continue using the older v3.1 Campaign Monitor API, please use the releases marked 5.x.x

### Get single subscriber ✓
- Api returns empty string for Unknown
	- Maps Unknown ConsentToTrack property on SubscriberDetail to null
### Add single subscriber ✓
- Not setting consent to track will cause exception on response
### Get list subscribers ✓
- Active
- Unsubscribed
- Deleted
- Bounced
- Unconfirmed
### Get segment subscribers ✓
### Bulk import ✓
- Not setting consent to track will cause exception on response
### Smart transactional ✓
### Classic transactional ✓

Also fixing 'Add recipient to list ID' field when sending classic transactional emails which is currently not working

