### PR TITLE
Use https API endpoint by default and removed unused imports

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,5 +1,9 @@
 # createsend-java history
 
+## v6.0.1 - 30 January 2019
+
+* Changed API endpoint to use https by default
+
 ## v6.0.0 - 28 May 2018
 
 * Upgrades to Createsend API v3.2 which includes new breaking changes

--- a/build.gradle
+++ b/build.gradle
@@ -7,7 +7,7 @@ install.dependsOn ':build'
 defaultTasks 'clean', 'install'
 
 sourceCompatibility = 1.7
-version = '6.0.0'
+version = '6.0.1'
 group = 'com.createsend'
 
 def localMavenRepo = 'file://' + new File(System.getProperty('user.home'), '.m2/repository').absolutePath

--- a/samples/com/createsend/samples/TransactionalSample.java
+++ b/samples/com/createsend/samples/TransactionalSample.java
@@ -30,7 +30,6 @@ import com.createsend.models.transactional.request.Attachment;
 import com.createsend.models.transactional.request.ClassicEmailRequest;
 import com.createsend.models.transactional.request.SmartEmailRequest;
 import com.createsend.models.transactional.response.*;
-import com.createsend.util.ApiKeyAuthenticationDetails;
 import com.createsend.util.OAuthAuthenticationDetails;
 import com.createsend.util.exceptions.CreateSendException;
 

--- a/src/com/createsend/CreateSendBase.java
+++ b/src/com/createsend/CreateSendBase.java
@@ -35,7 +35,7 @@ import com.createsend.util.OAuthAuthenticationDetails;
 import com.createsend.util.exceptions.CreateSendException;
 
 public abstract class CreateSendBase {
-	protected static final String urlEncodingScheme = "UTF-8";
+	protected static final String URL_ENCODING_SCHEME = "UTF-8";
 
 	protected JerseyClient jerseyClient = null;
 
@@ -54,8 +54,7 @@ public abstract class CreateSendBase {
 			String body = "grant_type=refresh_token";
 			try {
 				body += "&refresh_token="
-						+ URLEncoder.encode(oauthDetails.getRefreshToken(),
-								urlEncodingScheme);
+						+ URLEncoder.encode(oauthDetails.getRefreshToken(), URL_ENCODING_SCHEME);
 			} catch (UnsupportedEncodingException e) {
 				body = null;
 			}

--- a/src/com/createsend/General.java
+++ b/src/com/createsend/General.java
@@ -28,7 +28,6 @@ import java.util.Date;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.MultivaluedMap;
 
-import com.createsend.models.ApiKey;
 import com.createsend.models.ExternalSessionOptions;
 import com.createsend.models.ExternalSessionResult;
 import com.createsend.models.OAuthTokenDetails;
@@ -41,7 +40,6 @@ import com.createsend.util.Configuration;
 import com.createsend.util.JerseyClient;
 import com.createsend.util.JerseyClientImpl;
 import com.createsend.util.exceptions.CreateSendException;
-import com.createsend.util.jersey.AuthorisedResourceFactory;
 import com.sun.jersey.core.util.MultivaluedMapImpl;
 
 /**
@@ -79,10 +77,10 @@ public class General extends CreateSendBase {
     	String state) {
         String qs = "client_id=" + String.valueOf(clientID);
         try {
-			qs += "&redirect_uri=" + URLEncoder.encode(redirectUri, urlEncodingScheme);
-			qs += "&scope=" + URLEncoder.encode(scope, urlEncodingScheme);
+			qs += "&redirect_uri=" + URLEncoder.encode(redirectUri, URL_ENCODING_SCHEME);
+			qs += "&scope=" + URLEncoder.encode(scope, URL_ENCODING_SCHEME);
 			if (state != null)
-				qs += "&state=" + URLEncoder.encode(state, urlEncodingScheme);
+				qs += "&state=" + URLEncoder.encode(state, URL_ENCODING_SCHEME);
 		} catch (UnsupportedEncodingException e) {
 			qs = null;
 		}
@@ -110,9 +108,9 @@ public class General extends CreateSendBase {
     	String body = "grant_type=authorization_code";
     	try {
         	body += "&client_id=" + String.valueOf(clientID);
-        	body += "&client_secret=" + URLEncoder.encode(clientSecret, urlEncodingScheme);
-        	body += "&redirect_uri=" + URLEncoder.encode(redirectUri, urlEncodingScheme);
-        	body += "&code=" + URLEncoder.encode(code, urlEncodingScheme);
+        	body += "&client_secret=" + URLEncoder.encode(clientSecret, URL_ENCODING_SCHEME);
+        	body += "&redirect_uri=" + URLEncoder.encode(redirectUri, URL_ENCODING_SCHEME);
+        	body += "&code=" + URLEncoder.encode(code, URL_ENCODING_SCHEME);
 		} catch (UnsupportedEncodingException e) {
 			body = null;
 		}

--- a/src/com/createsend/models/transactional/request/SmartEmailRequest.java
+++ b/src/com/createsend/models/transactional/request/SmartEmailRequest.java
@@ -23,7 +23,6 @@ package com.createsend.models.transactional.request;
 
 import com.createsend.models.subscribers.ConsentToTrack;
 import org.codehaus.jackson.annotate.JsonIgnore;
-import org.codehaus.jackson.annotate.JsonUnwrapped;
 
 import java.util.*;
 

--- a/src/com/createsend/models/transactional/response/MessageSent.java
+++ b/src/com/createsend/models/transactional/response/MessageSent.java
@@ -23,8 +23,6 @@ package com.createsend.models.transactional.response;
 
 import org.codehaus.jackson.annotate.JsonProperty;
 
-import java.util.Date;
-import java.util.List;
 import java.util.UUID;
 
 public class MessageSent {

--- a/src/com/createsend/models/transactional/response/TransactionalClick.java
+++ b/src/com/createsend/models/transactional/response/TransactionalClick.java
@@ -38,7 +38,7 @@ public class TransactionalClick {
     @JsonProperty("Geolocation")
     private GeoLocation geoLocation;
 
-    @JsonProperty("URL")
+    @JsonProperty("Url")
     private String url;
 
     /**

--- a/src/com/createsend/util/config.properties
+++ b/src/com/createsend/util/config.properties
@@ -1,4 +1,4 @@
-createsend.version = 6.0.0
-createsend.endpoint = http://api.createsend.com/api/v3.2/
+createsend.version = 6.0.1
+createsend.endpoint = https://api.createsend.com/api/v3.2/
 createsend.oauthbaseuri = https://api.createsend.com/oauth/
 createsend.logging = false

--- a/src/com/createsend/util/jersey/JsonProvider.java
+++ b/src/com/createsend/util/jersey/JsonProvider.java
@@ -27,7 +27,6 @@ import java.io.OutputStream;
 import java.lang.annotation.Annotation;
 import java.lang.reflect.Type;
 import java.text.DateFormat;
-import java.text.FieldPosition;
 import java.text.ParsePosition;
 import java.text.SimpleDateFormat;
 import java.util.Date;
@@ -37,7 +36,6 @@ import javax.ws.rs.core.MultivaluedMap;
 
 import org.codehaus.jackson.jaxrs.JacksonJsonProvider;
 import org.codehaus.jackson.map.DeserializationConfig;
-import org.codehaus.jackson.map.JsonMappingException;
 import org.codehaus.jackson.map.ObjectMapper;
 import org.codehaus.jackson.map.annotate.JsonSerialize.Inclusion;
 


### PR DESCRIPTION
Use https API endpoint by default

Also closing off:
- https://github.com/campaignmonitor/createsend-java/pull/23 (removing unused import)
- https://github.com/campaignmonitor/createsend-java/pull/30 (incorrect casing when deserializing transactional click response --> confirmed that it is incorrect)
- https://github.com/campaignmonitor/createsend-java/pull/32 (correctly named constant)