### PR TITLE
Use https for contacting the API endpoint

### DIFF
--- a/src/com/createsend/util/config.properties
+++ b/src/com/createsend/util/config.properties
@@ -1,4 +1,4 @@
 createsend.version = 6.0.0
-createsend.endpoint = http://api.createsend.com/api/v3.2/
+createsend.endpoint = https://api.createsend.com/api/v3.2/
 createsend.oauthbaseuri = https://api.createsend.com/oauth/
 createsend.logging = false


### PR DESCRIPTION
As discussed with Jarrod Taylor over mail. This updates the jersey configuration to use https instead of http for contacting the campaignmonitor API.