### PR TITLE
EL-280 - (Version 7.0.0) - Support for CM API v3.3

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -6,7 +6,7 @@
 * New client tags() returns the list of tags 
 * Client draftCampaigns() now return Tags
 * Client scheduledCampaigns() now returns Tags
-* Revamped client sentCampaigns() includes these improvements: 
+* Breaking: Revamped client sentCampaigns() includes these improvements: 
   * The method returns a PagedResult of SentCampaign.
   * Entries can be fetched using the Page parameter.
   * Up to 1000 entries are returned per method call. A different amount can be returned by setting the PageSize value.

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,6 +1,6 @@
 # createsend-java history
 
-## v7.0.0 - 19 November 2021
+## v7.0.0 - 14 December 2021
 
 * Upgrades to Createsend API v3.3 which includes new breaking changes
 * New client tags() returns the list of tags 
@@ -14,6 +14,14 @@
   * Campaigns can be filtered by Sent Date using sentFromDate and sentToDate in YYYY-MM-DD format
   * Campaigns can be filtered by their tags.
 * Campaign summary() now returns Name
+* Adding support for returning ListJoinedDate for each subscriber. 
+  * List active()
+  * List bounce()
+  * List unsubscribe()
+  * List unconfirmed()
+  * List deleted()
+  * Segment active()
+  * Subscriber details()
 
 ## v6.1.1 - 21 February 2020
 

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,5 +1,20 @@
 # createsend-java history
 
+## v7.0.0 - 19 November 2021
+
+* Upgrades to Createsend API v3.3 which includes new breaking changes
+* New client tags() returns the list of tags 
+* Client draftCampaigns() now return Tags
+* Client scheduledCampaigns() now returns Tags
+* Revamped client sentCampaigns() includes these improvements: 
+  * The method returns a PagedResult of SentCampaign.
+  * Entries can be fetched using the Page parameter.
+  * Up to 1000 entries are returned per method call. A different amount can be returned by setting the PageSize value.
+  * Campaigns can be sorted by their Sent Date using OrderDirection
+  * Campaigns can be filtered by Sent Date using sentFromDate and sentToDate in YYYY-MM-DD format
+  * Campaigns can be filtered by their tags.
+* Campaign summary() now returns Name
+
 ## v6.1.1 - 21 February 2020
 
 * Fix Security Vulnerability  

--- a/README.md
+++ b/README.md
@@ -113,7 +113,7 @@ This example of listing all your clients and their campaigns demonstrates basic 
 ```java
 import com.createsend.Clients;
 import com.createsend.General;
-import com.createsend.models.campaigns.SentCampaign;
+import com.createsend.models.campaigns.DraftCampaign;
 import com.createsend.models.clients.ClientBasics;
 import com.createsend.util.OAuthAuthenticationDetails;
 import com.createsend.util.exceptions.CreateSendException;
@@ -130,7 +130,7 @@ public class Tester {
             System.out.printf("Client: %s\n", cl.Name);
             Clients cls = new Clients(auth, cl.ClientID);
             System.out.printf("- Campaigns:\n");
-            for (SentCampaign cm : cls.sentCampaigns()) {
+            for (DraftCampaign cm : cls.draftCampaigns()) {
                 System.out.printf("  - %s\n", cm.Subject);
             }
         }

--- a/build.gradle
+++ b/build.gradle
@@ -7,7 +7,7 @@ install.dependsOn ':build'
 defaultTasks 'clean', 'install'
 
 sourceCompatibility = 1.7
-version = '6.1.1'
+version = '7.0.0'
 group = 'com.createsend'
 
 def localMavenRepo = 'file://' + new File(System.getProperty('user.home'), '.m2/repository').absolutePath

--- a/build.gradle
+++ b/build.gradle
@@ -24,7 +24,7 @@ dependencies {
     compile group: 'com.fasterxml.jackson.jaxrs', name: 'jackson-jaxrs-json-provider', version: '2.10.2'
     compile group: 'com.fasterxml.jackson.core', name: 'jackson-databind', version: '2.10.2'
     compile group: 'commons-codec', name: 'commons-codec', version: '1.10'
-    compile group: 'commons-io', name: 'commons-io', version: '2.4'
+    compile group: 'commons-io', name: 'commons-io', version: '2.7'
 }
 
 sourceSets {

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>com.createsend</groupId>
   <artifactId>createsend-java</artifactId>
-  <version>6.1.1-SNAPSHOT</version>
+  <version>7.0.0-SNAPSHOT</version>
   <name>createsend-java</name>
   <description>A Java library which implements the complete functionality of the Campaign Monitor API.</description>
   <url>http://campaignmonitor.github.io/createsend-java/</url>

--- a/pom.xml
+++ b/pom.xml
@@ -60,7 +60,7 @@
     <dependency>
       <groupId>commons-io</groupId>
       <artifactId>commons-io</artifactId>
-      <version>2.4</version>
+      <version>2.7</version>
     </dependency>
   </dependencies>
 

--- a/samples/com/createsend/samples/SampleRunner.java
+++ b/samples/com/createsend/samples/SampleRunner.java
@@ -550,7 +550,7 @@ public class SampleRunner {
                 Arrays.deepToString(clientAPI.sentCampaigns().Results));
 
         try {
-            String[] tags = "tag1, tag2";
+            String tags = "tag1, tag2";
             SimpleDateFormat yyyyMMdd = new SimpleDateFormat("yyyy-MM-dd");
             Date sentFromDate = yyyyMMdd.parse("2000-01-01");
             Date sentToDate = new Date();

--- a/samples/com/createsend/samples/SampleRunner.java
+++ b/samples/com/createsend/samples/SampleRunner.java
@@ -79,7 +79,7 @@ public class SampleRunner {
     /**
      * @param args
      */
-    public static void main(String[] args) {        
+    public static void main(String[] args) {
         try {
             String clientID = "Client ID";
             runGeneralMethods();
@@ -312,6 +312,32 @@ public class SampleRunner {
         listAPI.deleteWebhook(webhook.WebhookID);
         
         listAPI.delete();
+    }
+
+    private static void testListSubscribers(String listId) throws CreateSendException {
+        Lists listAPI = new Lists(auth, listId);
+
+        Date subscribersFrom = new Date();
+
+        System.out.printf("Result of list active: %s\n",
+                listAPI.active(subscribersFrom, null, null, null, null));
+        System.out.printf("Result of list unsubscribed: %s\n",
+                listAPI.unsubscribed(subscribersFrom, null, null, null, null));
+        System.out.printf("Result of list unconfirmed: %s\n",
+                listAPI.unconfirmed(subscribersFrom, null, null, null, null));
+        System.out.printf("Result of list bounced: %s\n",
+                listAPI.bounced(subscribersFrom, null, null, null, null));
+        System.out.printf("Result of list deleted: %s\n",
+                listAPI.deleted(subscribersFrom, null, null, null, null));
+    }
+
+    private static void testActiveSegmentSubscribers(String segmentID) throws CreateSendException {
+        Segments segmentsAPI = new Segments(auth, segmentID);
+
+        Date subscribersFrom = new Date();
+
+        System.out.printf("Result of segment active: %s\n",
+                segmentsAPI.active(subscribersFrom, null, null, null, null));
     }
 
     private static void testCampaignCreationFromTemplate(

--- a/samples/com/createsend/samples/SampleRunner.java
+++ b/samples/com/createsend/samples/SampleRunner.java
@@ -550,7 +550,7 @@ public class SampleRunner {
                 Arrays.deepToString(clientAPI.sentCampaigns().Results));
 
         try {
-            String[] tags = {"tag1", "tag2"};
+            String[] tags = "tag1, tag2";
             SimpleDateFormat yyyyMMdd = new SimpleDateFormat("yyyy-MM-dd");
             Date sentFromDate = yyyyMMdd.parse("2000-01-01");
             Date sentToDate = new Date();

--- a/src/com/createsend/Campaigns.java
+++ b/src/com/createsend/Campaigns.java
@@ -189,7 +189,7 @@ public class Campaigns extends CreateSendBase {
     
     /**
      * Gets a paged list of recipients for the specified campaign
-     * @param page The page number or results to get. Use <code>null</code> for the default (page=1)
+     * @param page the page number of results to get. Use <code>null</code> for the default (page=1)
      * @param pageSize The number of records to get on the current page. Use <code>null</code> for the default.
      * @param orderField The field used to order the results by. Use <code>null</code> for the default.
      * @param orderDirection The direction to order the results by. Use <code>null</code> for the default.
@@ -217,7 +217,7 @@ public class Campaigns extends CreateSendBase {
 
     /**
      * Gets a paged list of bounces for the specified campaign
-     * @param page The page number or results to get. Use <code>null</code> for the default (page=1)
+     * @param page the page number of results to get. Use <code>null</code> for the default (page=1)
      * @param pageSize The number of records to get on the current page. Use <code>null</code> for the default.
      * @param orderField The field used to order the results by. Use <code>null</code> for the default.
      * @param orderDirection The direction to order the results by. Use <code>null</code> for the default.
@@ -234,7 +234,7 @@ public class Campaigns extends CreateSendBase {
     /**
      * Gets a paged list of bounces for the specified campaign
      * @param bouncesFrom The date to start getting bounce results from. This field is required
-     * @param page The page number or results to get. Use <code>null</code> for the default (page=1)
+     * @param page the page number of results to get. Use <code>null</code> for the default (page=1)
      * @param pageSize The number of records to get on the current page. Use <code>null</code> for the default.
      * @param orderField The field used to order the results by. Use <code>null</code> for the default.
      * @param orderDirection The direction to order the results by. Use <code>null</code> for the default.
@@ -271,7 +271,7 @@ public class Campaigns extends CreateSendBase {
     
     /**
      * Gets a paged list of opens for the specified campaign
-     * @param page The page number or results to get. Use <code>null</code> for the default (page=1)
+     * @param page the page number of results to get. Use <code>null</code> for the default (page=1)
      * @param pageSize The number of records to get on the current page. Use <code>null</code> for the default.
      * @param orderField The field used to order the results by. Use <code>null</code> for the default.
      * @param orderDirection The direction to order the results by. Use <code>null</code> for the default.
@@ -288,7 +288,7 @@ public class Campaigns extends CreateSendBase {
     /**
      * Gets a paged list of opens for the specified campaign
      * @param opensFrom The date to start getting open results from. This field is required
-     * @param page The page number or results to get. Use <code>null</code> for the default (page=1)
+     * @param page the page number of results to get. Use <code>null</code> for the default (page=1)
      * @param pageSize The number of records to get on the current page. Use <code>null</code> for the default.
      * @param orderField The field used to order the results by. Use <code>null</code> for the default.
      * @param orderDirection The direction to order the results by. Use <code>null</code> for the default.
@@ -325,7 +325,7 @@ public class Campaigns extends CreateSendBase {
 
     /**
      * Gets a paged list of clicks for the specified campaign
-     * @param page The page number or results to get. Use <code>null</code> for the default (page=1)
+     * @param page the page number of results to get. Use <code>null</code> for the default (page=1)
      * @param pageSize The number of records to get on the current page. Use <code>null</code> for the default.
      * @param orderField The field used to order the results by. Use <code>null</code> for the default.
      * @param orderDirection The direction to order the results by. Use <code>null</code> for the default.
@@ -342,7 +342,7 @@ public class Campaigns extends CreateSendBase {
     /**
      * Gets a paged list of clicks for the specified campaign
      * @param clicksFrom The date to start getting click results from. This field is required
-     * @param page The page number or results to get. Use <code>null</code> for the default (page=1)
+     * @param page the page number of results to get. Use <code>null</code> for the default (page=1)
      * @param pageSize The number of records to get on the current page. Use <code>null</code> for the default.
      * @param orderField The field used to order the results by. Use <code>null</code> for the default.
      * @param orderDirection The direction to order the results by. Use <code>null</code> for the default.
@@ -379,7 +379,7 @@ public class Campaigns extends CreateSendBase {
 
     /**
      * Gets a paged list of unsubscribes for the specified campaign
-     * @param page The page number or results to get. Use <code>null</code> for the default (page=1)
+     * @param page the page number of results to get. Use <code>null</code> for the default (page=1)
      * @param pageSize The number of records to get on the current page. Use <code>null</code> for the default.
      * @param orderField The field used to order the results by. Use <code>null</code> for the default.
      * @param orderDirection The direction to order the results by. Use <code>null</code> for the default.
@@ -396,7 +396,7 @@ public class Campaigns extends CreateSendBase {
     /**
      * Gets a paged list of unsubscribes for the specified campaign
      * @param unsubscribesFrom The date to start getting unsubscribe results from. This field is required
-     * @param page The page number or results to get. Use <code>null</code> for the default (page=1)
+     * @param page the page number of results to get. Use <code>null</code> for the default (page=1)
      * @param pageSize The number of records to get on the current page. Use <code>null</code> for the default.
      * @param orderField The field used to order the results by. Use <code>null</code> for the default.
      * @param orderDirection The direction to order the results by. Use <code>null</code> for the default.
@@ -433,7 +433,7 @@ public class Campaigns extends CreateSendBase {
 
     /**
      * Gets a paged list of spam complaints for the specified campaign
-     * @param page The page number or results to get. Use <code>null</code> for the default (page=1)
+     * @param page the page number of results to get. Use <code>null</code> for the default (page=1)
      * @param pageSize The number of records to get on the current page. Use <code>null</code> for the default.
      * @param orderField The field used to order the results by. Use <code>null</code> for the default.
      * @param orderDirection The direction to order the results by. Use <code>null</code> for the default.
@@ -450,7 +450,7 @@ public class Campaigns extends CreateSendBase {
     /**
      * Gets a paged list of spam complaints for the specified campaign
      * @param spamComplaintsFrom The date to start getting spam complaints from. This field is required
-     * @param page The page number or results to get. Use <code>null</code> for the default (page=1)
+     * @param page the page number of results to get. Use <code>null</code> for the default (page=1)
      * @param pageSize The number of records to get on the current page. Use <code>null</code> for the default.
      * @param orderField The field used to order the results by. Use <code>null</code> for the default.
      * @param orderDirection The direction to order the results by. Use <code>null</code> for the default.

--- a/src/com/createsend/Campaigns.java
+++ b/src/com/createsend/Campaigns.java
@@ -189,7 +189,7 @@ public class Campaigns extends CreateSendBase {
     
     /**
      * Gets a paged list of recipients for the specified campaign
-     * @param page the page number of results to get. Use <code>null</code> for the default (page=1)
+     * @param page The page number of results to get. Use <code>null</code> for the default (page=1)
      * @param pageSize The number of records to get on the current page. Use <code>null</code> for the default.
      * @param orderField The field used to order the results by. Use <code>null</code> for the default.
      * @param orderDirection The direction to order the results by. Use <code>null</code> for the default.
@@ -217,7 +217,7 @@ public class Campaigns extends CreateSendBase {
 
     /**
      * Gets a paged list of bounces for the specified campaign
-     * @param page the page number of results to get. Use <code>null</code> for the default (page=1)
+     * @param page The page number of results to get. Use <code>null</code> for the default (page=1)
      * @param pageSize The number of records to get on the current page. Use <code>null</code> for the default.
      * @param orderField The field used to order the results by. Use <code>null</code> for the default.
      * @param orderDirection The direction to order the results by. Use <code>null</code> for the default.
@@ -234,7 +234,7 @@ public class Campaigns extends CreateSendBase {
     /**
      * Gets a paged list of bounces for the specified campaign
      * @param bouncesFrom The date to start getting bounce results from. This field is required
-     * @param page the page number of results to get. Use <code>null</code> for the default (page=1)
+     * @param page The page number of results to get. Use <code>null</code> for the default (page=1)
      * @param pageSize The number of records to get on the current page. Use <code>null</code> for the default.
      * @param orderField The field used to order the results by. Use <code>null</code> for the default.
      * @param orderDirection The direction to order the results by. Use <code>null</code> for the default.
@@ -271,7 +271,7 @@ public class Campaigns extends CreateSendBase {
     
     /**
      * Gets a paged list of opens for the specified campaign
-     * @param page the page number of results to get. Use <code>null</code> for the default (page=1)
+     * @param page The page number of results to get. Use <code>null</code> for the default (page=1)
      * @param pageSize The number of records to get on the current page. Use <code>null</code> for the default.
      * @param orderField The field used to order the results by. Use <code>null</code> for the default.
      * @param orderDirection The direction to order the results by. Use <code>null</code> for the default.
@@ -288,7 +288,7 @@ public class Campaigns extends CreateSendBase {
     /**
      * Gets a paged list of opens for the specified campaign
      * @param opensFrom The date to start getting open results from. This field is required
-     * @param page the page number of results to get. Use <code>null</code> for the default (page=1)
+     * @param page The page number of results to get. Use <code>null</code> for the default (page=1)
      * @param pageSize The number of records to get on the current page. Use <code>null</code> for the default.
      * @param orderField The field used to order the results by. Use <code>null</code> for the default.
      * @param orderDirection The direction to order the results by. Use <code>null</code> for the default.
@@ -325,7 +325,7 @@ public class Campaigns extends CreateSendBase {
 
     /**
      * Gets a paged list of clicks for the specified campaign
-     * @param page the page number of results to get. Use <code>null</code> for the default (page=1)
+     * @param page The page number of results to get. Use <code>null</code> for the default (page=1)
      * @param pageSize The number of records to get on the current page. Use <code>null</code> for the default.
      * @param orderField The field used to order the results by. Use <code>null</code> for the default.
      * @param orderDirection The direction to order the results by. Use <code>null</code> for the default.
@@ -342,7 +342,7 @@ public class Campaigns extends CreateSendBase {
     /**
      * Gets a paged list of clicks for the specified campaign
      * @param clicksFrom The date to start getting click results from. This field is required
-     * @param page the page number of results to get. Use <code>null</code> for the default (page=1)
+     * @param page The page number of results to get. Use <code>null</code> for the default (page=1)
      * @param pageSize The number of records to get on the current page. Use <code>null</code> for the default.
      * @param orderField The field used to order the results by. Use <code>null</code> for the default.
      * @param orderDirection The direction to order the results by. Use <code>null</code> for the default.
@@ -379,7 +379,7 @@ public class Campaigns extends CreateSendBase {
 
     /**
      * Gets a paged list of unsubscribes for the specified campaign
-     * @param page the page number of results to get. Use <code>null</code> for the default (page=1)
+     * @param page The page number of results to get. Use <code>null</code> for the default (page=1)
      * @param pageSize The number of records to get on the current page. Use <code>null</code> for the default.
      * @param orderField The field used to order the results by. Use <code>null</code> for the default.
      * @param orderDirection The direction to order the results by. Use <code>null</code> for the default.
@@ -396,7 +396,7 @@ public class Campaigns extends CreateSendBase {
     /**
      * Gets a paged list of unsubscribes for the specified campaign
      * @param unsubscribesFrom The date to start getting unsubscribe results from. This field is required
-     * @param page the page number of results to get. Use <code>null</code> for the default (page=1)
+     * @param page The page number of results to get. Use <code>null</code> for the default (page=1)
      * @param pageSize The number of records to get on the current page. Use <code>null</code> for the default.
      * @param orderField The field used to order the results by. Use <code>null</code> for the default.
      * @param orderDirection The direction to order the results by. Use <code>null</code> for the default.
@@ -433,7 +433,7 @@ public class Campaigns extends CreateSendBase {
 
     /**
      * Gets a paged list of spam complaints for the specified campaign
-     * @param page the page number of results to get. Use <code>null</code> for the default (page=1)
+     * @param page The page number of results to get. Use <code>null</code> for the default (page=1)
      * @param pageSize The number of records to get on the current page. Use <code>null</code> for the default.
      * @param orderField The field used to order the results by. Use <code>null</code> for the default.
      * @param orderDirection The direction to order the results by. Use <code>null</code> for the default.
@@ -450,7 +450,7 @@ public class Campaigns extends CreateSendBase {
     /**
      * Gets a paged list of spam complaints for the specified campaign
      * @param spamComplaintsFrom The date to start getting spam complaints from. This field is required
-     * @param page the page number of results to get. Use <code>null</code> for the default (page=1)
+     * @param page The page number of results to get. Use <code>null</code> for the default (page=1)
      * @param pageSize The number of records to get on the current page. Use <code>null</code> for the default.
      * @param orderField The field used to order the results by. Use <code>null</code> for the default.
      * @param orderDirection The direction to order the results by. Use <code>null</code> for the default.

--- a/src/com/createsend/Clients.java
+++ b/src/com/createsend/Clients.java
@@ -21,8 +21,6 @@
  */
 package com.createsend;
 
-import javax.ws.rs.core.MultivaluedMap;
-
 import com.createsend.models.PagedResult;
 import com.createsend.models.campaigns.DraftCampaign;
 import com.createsend.models.campaigns.ScheduledCampaign;
@@ -30,10 +28,11 @@ import com.createsend.models.campaigns.SentCampaign;
 import com.createsend.models.clients.AllClientDetails;
 import com.createsend.models.clients.BillingDetails;
 import com.createsend.models.clients.Client;
-import com.createsend.models.clients.SuppressionDetails;
-import com.createsend.models.clients.Template;
 import com.createsend.models.clients.CreditsTransferDetails;
 import com.createsend.models.clients.CreditsTransferResult;
+import com.createsend.models.clients.SuppressionDetails;
+import com.createsend.models.clients.Tag;
+import com.createsend.models.clients.Template;
 import com.createsend.models.journeys.JourneyDetail;
 import com.createsend.models.lists.ListBasics;
 import com.createsend.models.lists.ListForEmail;
@@ -44,7 +43,11 @@ import com.createsend.models.subscribers.SuppressedSubscriber;
 import com.createsend.util.AuthenticationDetails;
 import com.createsend.util.JerseyClientImpl;
 import com.createsend.util.exceptions.CreateSendException;
+import com.createsend.util.jersey.JsonProvider;
 import com.sun.jersey.core.util.MultivaluedMapImpl;
+
+import javax.ws.rs.core.MultivaluedMap;
+import java.util.Date;
 
 /**
  * Provides methods for accessing all <a href="http://www.campaignmonitor.com/api/clients/" target="_blank">
@@ -116,16 +119,95 @@ public class Clients extends CreateSendBase {
     public AllClientDetails details() throws CreateSendException {
         return jerseyClient.get(AllClientDetails.class, "clients", clientID + ".json");
     }
-   
+
     /**
-     * Gets all campaigns sent by the current client
-     * @return All campaigns which have been sent by the current client
+     * Gets all tags of the current client
+     * @return All client tags
      * @throws CreateSendException Thrown when the API responds with HTTP Status >= 400
+     * @see <a href="http://www.campaignmonitor.com/api/clients/#getting_tags" target="_blank">
+     * Getting tags</a>
+     */
+    public Tag[] tags() throws CreateSendException {
+        return jerseyClient.get(Tag[].class, "clients", clientID, "tags.json");
+    }
+
+    /**
+     * Gets a paged list of campaigns sent by the current client
+     * @return The paged campaigns returned by the api call.
+     * @throws CreateSendException Thrown when the API responds with a HTTP Status >= 400
      * @see <a href="http://www.campaignmonitor.com/api/clients/#getting_client_campaigns" target="_blank">
      * Getting sent campaigns</a>
      */
-    public SentCampaign[] sentCampaigns() throws CreateSendException {
-        return jerseyClient.get(SentCampaign[].class, "clients", clientID, "campaigns.json");
+    public PagedResult<SentCampaign> sentCampaigns() throws CreateSendException {
+        return sentCampaigns(1, 1000, "desc");
+    }
+
+    /**
+     * Gets a paged list of campaigns sent by the current client
+     * @param page The page number of results to get. Use <code>null</code> for the default (page=1)
+     * @param pageSize The number of records to get on the current page. Use <code>null</code> for the default.
+     * @param orderDirection The direction to order results by. Use <code>null</code> for the default.
+     * @return The paged campaigns returned by the api call
+     * @throws CreateSendException Thrown when the API responds with a HTTP Status >= 400
+     * @see <a href="http://www.campaignmonitor.com/api/clients/#getting_client_campaigns" target="_blank">
+     * Getting sent campaigns</a>
+     */
+    public PagedResult<SentCampaign> sentCampaigns(
+            Integer page, Integer pageSize, String orderDirection) throws CreateSendException {
+        return sentCampaigns("", "", null, page, pageSize, orderDirection);
+    }
+
+    /**
+     * Gets a paged list of campaigns sent by the current client
+     * @param sentFromDate Campaigns sent on or after the <code>sentFromDate/code> value specified will be returned.
+     *                     Must be in the format YYYY-MM-DD. If not provided, results will go back to the beginning of the client’s history.
+     *                     Use <code>null</code> for the default
+     * @param sentToDate Campaigns sent on or before the <code>sentToDate/code> value specified will be returned.
+     *                   Must be in the format YYYY-MM-DD. If not provided, results will include the most recent sent campaigns.
+     *                   Use <code>null</code> for the default
+     * @param tags An array of tags to filter sent campaigns.
+     *             Sent campaigns with all the tags specified will be returned.
+     *             Use <code>null</code> for the default
+     * @param page The page number of results to get. Use <code>null</code> for the default (page=1)
+     * @param pageSize The number of records to get on the current page.
+     *                 The value can be between 1 and 1000.
+     *                 Use <code>null</code> for the default.
+     * @param orderDirection The direction to order results by.
+     *                       The value can be ASC or DESC
+     *                       Use <code>null</code> for the default (DESC)
+     * @return The paged campaigns returned by the api call
+     * @throws CreateSendException Thrown when the API responds with a HTTP Status >= 400
+     * @see <a href="http://www.campaignmonitor.com/api/clients/#getting_client_campaigns" target="_blank">
+     * Getting sent campaigns</a>
+     */
+    public PagedResult<SentCampaign> sentCampaigns(
+            Date sentFromDate, Date sentToDate, String[] tags,
+            Integer page, Integer pageSize, String orderDirection) throws CreateSendException {
+
+        String csvTags = "";
+        if (tags != null) {
+            for (int i = 0; i < tags.length; i++) {
+                csvTags += (i > 0 ? "," : "") + tags[i];
+            }
+        }
+
+        return sentCampaigns(
+                sentFromDate != null ? JsonProvider.ApiDateFormat.format(sentFromDate) : null,
+                sentToDate != null ? JsonProvider.ApiDateFormat.format(sentToDate) : null,
+                csvTags,
+                page, pageSize, orderDirection);
+    }
+
+    private PagedResult<SentCampaign> sentCampaigns(
+            String sentFromDate, String sentToDate, String tags,
+            Integer page, Integer pageSize, String orderDirection) throws CreateSendException {
+        MultivaluedMap<String, String> queryString = new MultivaluedMapImpl();
+        queryString.add("sentFromDate", sentFromDate);
+        queryString.add("sentToDate", sentToDate);
+        queryString.add("tags", tags);
+
+        return jerseyClient.getPagedResult(page, pageSize, null, orderDirection, queryString,
+                "clients", clientID, "campaigns.json");
     }
    
     /**
@@ -190,7 +272,7 @@ public class Clients extends CreateSendBase {
    
     /**
      * Gets a paged collection of subscribers who are suppressed from the current clients lists.
-     * @param page The page number or results to get. Use <code>null</code> for the default (page=1)
+     * @param page The page number of results to get. Use <code>null</code> for the default (page=1)
      * @param pageSize The number of records to get on the current page. Use <code>null</code> for the default.
      * @param orderField The field used to order the results by. Use <code>null</code> for the default.
      * @param orderDirection The direction to order the results by. Use <code>null</code> for the default.

--- a/src/com/createsend/Clients.java
+++ b/src/com/createsend/Clients.java
@@ -181,20 +181,12 @@ public class Clients extends CreateSendBase {
      * Getting sent campaigns</a>
      */
     public PagedResult<SentCampaign> sentCampaigns(
-            Date sentFromDate, Date sentToDate, String[] tags,
+            Date sentFromDate, Date sentToDate, String tags,
             Integer page, Integer pageSize, String orderDirection) throws CreateSendException {
-
-        String csvTags = "";
-        if (tags != null) {
-            for (int i = 0; i < tags.length; i++) {
-                csvTags += (i > 0 ? "," : "") + tags[i];
-            }
-        }
-
         return sentCampaigns(
                 sentFromDate != null ? JsonProvider.ApiDateFormat.format(sentFromDate) : null,
                 sentToDate != null ? JsonProvider.ApiDateFormat.format(sentToDate) : null,
-                csvTags,
+                tags,
                 page, pageSize, orderDirection);
     }
 

--- a/src/com/createsend/JourneyEmails.java
+++ b/src/com/createsend/JourneyEmails.java
@@ -36,7 +36,7 @@ public class JourneyEmails extends CreateSendBase {
 
     /**
      * Gets a paged list of recipients for the specified journey email
-     * @param page The page number or results to get. Use <code>null</code> for the default (page=1)
+     * @param page the page number of results to get. Use <code>null</code> for the default (page=1)
      * @param pageSize The number of records to get on the current page. Use <code>null</code> for the default.
      * @param orderDirection orderDirection The direction to order the results by. Use <code>null</code> for the default.
      * @return The paged recipients returned by the api call.
@@ -52,7 +52,7 @@ public class JourneyEmails extends CreateSendBase {
     /**
      * Gets a paged list of recipients for the specified journey email
      * @param fromDate The date to start getting bounce results from. This field is required
-     * @param page The page number or results to get. Use <code>null</code> for the default (page=1)
+     * @param page the page number of results to get. Use <code>null</code> for the default (page=1)
      * @param pageSize The number of records to get on the current page. Use <code>null</code> for the default.
      * @param orderDirection orderDirection The direction to order the results by. Use <code>null</code> for the default.
      * @return The paged recipients returned by the api call.
@@ -87,7 +87,7 @@ public class JourneyEmails extends CreateSendBase {
 
     /**
      * Gets a paged list of bounces for the specified journey email
-     * @param page The page number or results to get. Use <code>null</code> for the default (page=1)
+     * @param page the page number of results to get. Use <code>null</code> for the default (page=1)
      * @param pageSize The number of records to get on the current page. Use <code>null</code> for the default.
      * @param orderDirection The direction to order the results by. Use <code>null</code> for the default.
      * @return The paged bounces returned by the api call.
@@ -103,7 +103,7 @@ public class JourneyEmails extends CreateSendBase {
     /**
      * Gets a paged list of bounces for the specified journey email
      * @param bouncesFrom The date to start getting bounce results from. This field is required
-     * @param page The page number or results to get. Use <code>null</code> for the default (page=1)
+     * @param page the page number of results to get. Use <code>null</code> for the default (page=1)
      * @param pageSize The number of records to get on the current page. Use <code>null</code> for the default.
      * @param orderDirection The direction to order the results by. Use <code>null</code> for the default.
      * @return The paged bounces returned by the api call.
@@ -138,7 +138,7 @@ public class JourneyEmails extends CreateSendBase {
 
     /**
      * Gets a paged list of opens for the specified journey email
-     * @param page The page number or results to get. Use <code>null</code> for the default (page=1)
+     * @param page the page number of results to get. Use <code>null</code> for the default (page=1)
      * @param pageSize The number of records to get on the current page. Use <code>null</code> for the default.
      * @param orderDirection The direction to order the results by. Use <code>null</code> for the default.
      * @return The paged opens returned by the api call.
@@ -154,7 +154,7 @@ public class JourneyEmails extends CreateSendBase {
     /**
      * Gets a paged list of opens for the specified journey email
      * @param opensFrom The date to start getting open results from. This field is required
-     * @param page The page number or results to get. Use <code>null</code> for the default (page=1)
+     * @param page the page number of results to get. Use <code>null</code> for the default (page=1)
      * @param pageSize The number of records to get on the current page. Use <code>null</code> for the default.
      * @param orderDirection The direction to order the results by. Use <code>null</code> for the default.
      * @return The paged opens returned by the api call.
@@ -189,7 +189,7 @@ public class JourneyEmails extends CreateSendBase {
 
     /**
      * Gets a paged list of clicks for the specified journey email
-     * @param page The page number or results to get. Use <code>null</code> for the default (page=1)
+     * @param page the page number of results to get. Use <code>null</code> for the default (page=1)
      * @param pageSize The number of records to get on the current page. Use <code>null</code> for the default.
      * @param orderDirection The direction to order the results by. Use <code>null</code> for the default.
      * @return The paged clicks returned by the api call.
@@ -205,7 +205,7 @@ public class JourneyEmails extends CreateSendBase {
     /**
      * Gets a paged list of clicks for the specified journey email
      * @param clicksFrom The date to start getting click results from. This field is required
-     * @param page The page number or results to get. Use <code>null</code> for the default (page=1)
+     * @param page the page number of results to get. Use <code>null</code> for the default (page=1)
      * @param pageSize The number of records to get on the current page. Use <code>null</code> for the default.
      * @param orderDirection The direction to order the results by. Use <code>null</code> for the default.
      * @return The paged clicks returned by the api call.
@@ -240,7 +240,7 @@ public class JourneyEmails extends CreateSendBase {
 
     /**
      * Gets a paged list of unsubscribes for the specified journey email
-     * @param page The page number or results to get. Use <code>null</code> for the default (page=1)
+     * @param page the page number of results to get. Use <code>null</code> for the default (page=1)
      * @param pageSize The number of records to get on the current page. Use <code>null</code> for the default.
      * @param orderDirection The direction to order the results by. Use <code>null</code> for the default.
      * @return The paged unsubscribes returned by the api call.
@@ -256,7 +256,7 @@ public class JourneyEmails extends CreateSendBase {
     /**
      * Gets a paged list of unsubscribes for the specified journey email
      * @param unsubscribesFrom The date to start getting unsubscribe results from. This field is required
-     * @param page The page number or results to get. Use <code>null</code> for the default (page=1)
+     * @param page the page number of results to get. Use <code>null</code> for the default (page=1)
      * @param pageSize The number of records to get on the current page. Use <code>null</code> for the default.
      * @param orderDirection The direction to order the results by. Use <code>null</code> for the default.
      * @return The paged unsubscribes returned by the api call.

--- a/src/com/createsend/JourneyEmails.java
+++ b/src/com/createsend/JourneyEmails.java
@@ -36,7 +36,7 @@ public class JourneyEmails extends CreateSendBase {
 
     /**
      * Gets a paged list of recipients for the specified journey email
-     * @param page the page number of results to get. Use <code>null</code> for the default (page=1)
+     * @param page The page number of results to get. Use <code>null</code> for the default (page=1)
      * @param pageSize The number of records to get on the current page. Use <code>null</code> for the default.
      * @param orderDirection orderDirection The direction to order the results by. Use <code>null</code> for the default.
      * @return The paged recipients returned by the api call.
@@ -52,7 +52,7 @@ public class JourneyEmails extends CreateSendBase {
     /**
      * Gets a paged list of recipients for the specified journey email
      * @param fromDate The date to start getting bounce results from. This field is required
-     * @param page the page number of results to get. Use <code>null</code> for the default (page=1)
+     * @param page The page number of results to get. Use <code>null</code> for the default (page=1)
      * @param pageSize The number of records to get on the current page. Use <code>null</code> for the default.
      * @param orderDirection orderDirection The direction to order the results by. Use <code>null</code> for the default.
      * @return The paged recipients returned by the api call.
@@ -87,7 +87,7 @@ public class JourneyEmails extends CreateSendBase {
 
     /**
      * Gets a paged list of bounces for the specified journey email
-     * @param page the page number of results to get. Use <code>null</code> for the default (page=1)
+     * @param page The page number of results to get. Use <code>null</code> for the default (page=1)
      * @param pageSize The number of records to get on the current page. Use <code>null</code> for the default.
      * @param orderDirection The direction to order the results by. Use <code>null</code> for the default.
      * @return The paged bounces returned by the api call.
@@ -103,7 +103,7 @@ public class JourneyEmails extends CreateSendBase {
     /**
      * Gets a paged list of bounces for the specified journey email
      * @param bouncesFrom The date to start getting bounce results from. This field is required
-     * @param page the page number of results to get. Use <code>null</code> for the default (page=1)
+     * @param page The page number of results to get. Use <code>null</code> for the default (page=1)
      * @param pageSize The number of records to get on the current page. Use <code>null</code> for the default.
      * @param orderDirection The direction to order the results by. Use <code>null</code> for the default.
      * @return The paged bounces returned by the api call.
@@ -138,7 +138,7 @@ public class JourneyEmails extends CreateSendBase {
 
     /**
      * Gets a paged list of opens for the specified journey email
-     * @param page the page number of results to get. Use <code>null</code> for the default (page=1)
+     * @param page The page number of results to get. Use <code>null</code> for the default (page=1)
      * @param pageSize The number of records to get on the current page. Use <code>null</code> for the default.
      * @param orderDirection The direction to order the results by. Use <code>null</code> for the default.
      * @return The paged opens returned by the api call.
@@ -154,7 +154,7 @@ public class JourneyEmails extends CreateSendBase {
     /**
      * Gets a paged list of opens for the specified journey email
      * @param opensFrom The date to start getting open results from. This field is required
-     * @param page the page number of results to get. Use <code>null</code> for the default (page=1)
+     * @param page The page number of results to get. Use <code>null</code> for the default (page=1)
      * @param pageSize The number of records to get on the current page. Use <code>null</code> for the default.
      * @param orderDirection The direction to order the results by. Use <code>null</code> for the default.
      * @return The paged opens returned by the api call.
@@ -189,7 +189,7 @@ public class JourneyEmails extends CreateSendBase {
 
     /**
      * Gets a paged list of clicks for the specified journey email
-     * @param page the page number of results to get. Use <code>null</code> for the default (page=1)
+     * @param page The page number of results to get. Use <code>null</code> for the default (page=1)
      * @param pageSize The number of records to get on the current page. Use <code>null</code> for the default.
      * @param orderDirection The direction to order the results by. Use <code>null</code> for the default.
      * @return The paged clicks returned by the api call.
@@ -205,7 +205,7 @@ public class JourneyEmails extends CreateSendBase {
     /**
      * Gets a paged list of clicks for the specified journey email
      * @param clicksFrom The date to start getting click results from. This field is required
-     * @param page the page number of results to get. Use <code>null</code> for the default (page=1)
+     * @param page The page number of results to get. Use <code>null</code> for the default (page=1)
      * @param pageSize The number of records to get on the current page. Use <code>null</code> for the default.
      * @param orderDirection The direction to order the results by. Use <code>null</code> for the default.
      * @return The paged clicks returned by the api call.
@@ -240,7 +240,7 @@ public class JourneyEmails extends CreateSendBase {
 
     /**
      * Gets a paged list of unsubscribes for the specified journey email
-     * @param page the page number of results to get. Use <code>null</code> for the default (page=1)
+     * @param page The page number of results to get. Use <code>null</code> for the default (page=1)
      * @param pageSize The number of records to get on the current page. Use <code>null</code> for the default.
      * @param orderDirection The direction to order the results by. Use <code>null</code> for the default.
      * @return The paged unsubscribes returned by the api call.
@@ -256,7 +256,7 @@ public class JourneyEmails extends CreateSendBase {
     /**
      * Gets a paged list of unsubscribes for the specified journey email
      * @param unsubscribesFrom The date to start getting unsubscribe results from. This field is required
-     * @param page the page number of results to get. Use <code>null</code> for the default (page=1)
+     * @param page The page number of results to get. Use <code>null</code> for the default (page=1)
      * @param pageSize The number of records to get on the current page. Use <code>null</code> for the default.
      * @param orderDirection The direction to order the results by. Use <code>null</code> for the default.
      * @return The paged unsubscribes returned by the api call.

--- a/src/com/createsend/Lists.java
+++ b/src/com/createsend/Lists.java
@@ -195,7 +195,7 @@ public class Lists extends CreateSendBase {
 
     /**
      * Gets a paged collection of active subscribers who have subscribed to the list.
-     * @param page the page number of results to get. Use <code>null</code> for the default (page=1)
+     * @param page The page number of results to get. Use <code>null</code> for the default (page=1)
      * @param pageSize The number of records to get on the current page. Use <code>null</code> for the default.
      * @param orderField The field used to order the results by. Use <code>null</code> for the default.
      * @param orderDirection The direction to order the results by. Use <code>null</code> for the default.
@@ -211,7 +211,7 @@ public class Lists extends CreateSendBase {
 
     /**
      * Gets a paged collection of active subscribers who have subscribed to the list.
-     * @param page the page number of results to get. Use <code>null</code> for the default (page=1)
+     * @param page The page number of results to get. Use <code>null</code> for the default (page=1)
      * @param pageSize The number of records to get on the current page. Use <code>null</code> for the default.
      * @param orderField The field used to order the results by. Use <code>null</code> for the default.
      * @param orderDirection The direction to order the results by. Use <code>null</code> for the default.
@@ -231,7 +231,7 @@ public class Lists extends CreateSendBase {
      * since the provided date.
      * @param subscribedFrom The API will only return subscribers who became active on or after this date. 
      *     This field is required
-     * @param page the page number of results to get. Use <code>null</code> for the default (page=1)
+     * @param page The page number of results to get. Use <code>null</code> for the default (page=1)
      * @param pageSize The number of records to get on the current page. Use <code>null</code> for the default.
      * @param orderField The field used to order the results by. Use <code>null</code> for the default.
      * @param orderDirection The direction to order the results by. Use <code>null</code> for the default.
@@ -251,7 +251,7 @@ public class Lists extends CreateSendBase {
      * since the provided date.
      * @param subscribedFrom The API will only return subscribers who became active on or after this date.
      *     This field is required
-     * @param page the page number of results to get. Use <code>null</code> for the default (page=1)
+     * @param page The page number of results to get. Use <code>null</code> for the default (page=1)
      * @param pageSize The number of records to get on the current page. Use <code>null</code> for the default.
      * @param orderField The field used to order the results by. Use <code>null</code> for the default.
      * @param orderDirection The direction to order the results by. Use <code>null</code> for the default.
@@ -302,7 +302,7 @@ public class Lists extends CreateSendBase {
 
     /**
      * Gets a paged collection of unconfirmed subscribers who have subscribed to the list.
-     * @param page the page number of results to get. Use <code>null</code> for the default (page=1)
+     * @param page The page number of results to get. Use <code>null</code> for the default (page=1)
      * @param pageSize The number of records to get on the current page. Use <code>null</code> for the default.
      * @param orderField The field used to order the results by. Use <code>null</code> for the default.
      * @param orderDirection The direction to order the results by. Use <code>null</code> for the default.
@@ -318,7 +318,7 @@ public class Lists extends CreateSendBase {
 
     /**
      * Gets a paged collection of unconfirmed subscribers who have subscribed to the list.
-     * @param page the page number of results to get. Use <code>null</code> for the default (page=1)
+     * @param page The page number of results to get. Use <code>null</code> for the default (page=1)
      * @param pageSize The number of records to get on the current page. Use <code>null</code> for the default.
      * @param orderField The field used to order the results by. Use <code>null</code> for the default.
      * @param orderDirection The direction to order the results by. Use <code>null</code> for the default.
@@ -338,7 +338,7 @@ public class Lists extends CreateSendBase {
      * since the provided date.
      * @param subscribedFrom The API will only return subscribers who subscribed on or after this date. 
      *     This field is required
-     * @param page the page number of results to get. Use <code>null</code> for the default (page=1)
+     * @param page The page number of results to get. Use <code>null</code> for the default (page=1)
      * @param pageSize The number of records to get on the current page. Use <code>null</code> for the default.
      * @param orderField The field used to order the results by. Use <code>null</code> for the default.
      * @param orderDirection The direction to order the results by. Use <code>null</code> for the default.
@@ -358,7 +358,7 @@ public class Lists extends CreateSendBase {
      * since the provided date.
      * @param subscribedFrom The API will only return subscribers who subscribed on or after this date.
      *     This field is required
-     * @param page the page number of results to get. Use <code>null</code> for the default (page=1)
+     * @param page The page number of results to get. Use <code>null</code> for the default (page=1)
      * @param pageSize The number of records to get on the current page. Use <code>null</code> for the default.
      * @param orderField The field used to order the results by. Use <code>null</code> for the default.
      * @param orderDirection The direction to order the results by. Use <code>null</code> for the default.
@@ -410,7 +410,7 @@ public class Lists extends CreateSendBase {
 
     /**
      * Gets a paged collection of unsubscribed subscribers who have unsubscribed from the list.
-     * @param page the page number of results to get. Use <code>null</code> for the default (page=1)
+     * @param page The page number of results to get. Use <code>null</code> for the default (page=1)
      * @param pageSize The number of records to get on the current page. Use <code>null</code> for the default.
      * @param orderField The field used to order the results by. Use <code>null</code> for the default.
      * @param orderDirection The direction to order the results by. Use <code>null</code> for the default.
@@ -426,7 +426,7 @@ public class Lists extends CreateSendBase {
 
     /**
      * Gets a paged collection of unsubscribed subscribers who have unsubscribed from the list.
-     * @param page the page number of results to get. Use <code>null</code> for the default (page=1)
+     * @param page The page number of results to get. Use <code>null</code> for the default (page=1)
      * @param pageSize The number of records to get on the current page. Use <code>null</code> for the default.
      * @param orderField The field used to order the results by. Use <code>null</code> for the default.
      * @param orderDirection The direction to order the results by. Use <code>null</code> for the default.
@@ -445,7 +445,7 @@ public class Lists extends CreateSendBase {
      * Gets a paged collection of unsubscribed subscribers who have unsubscribed from the list 
      * since the provided date.
      * @param subscribedFrom The API will only return subscribers who unsubscribed on or after this date. 
-     * @param page the page number of results to get. Use <code>null</code> for the default (page=1)
+     * @param page The page number of results to get. Use <code>null</code> for the default (page=1)
      * @param pageSize The number of records to get on the current page. Use <code>null</code> for the default.
      * @param orderField The field used to order the results by. Use <code>null</code> for the default.
      * @param orderDirection The direction to order the results by. Use <code>null</code> for the default.
@@ -464,7 +464,7 @@ public class Lists extends CreateSendBase {
      * Gets a paged collection of unsubscribed subscribers who have unsubscribed from the list
      * since the provided date.
      * @param subscribedFrom The API will only return subscribers who unsubscribed on or after this date.
-     * @param page the page number of results to get. Use <code>null</code> for the default (page=1)
+     * @param page The page number of results to get. Use <code>null</code> for the default (page=1)
      * @param pageSize The number of records to get on the current page. Use <code>null</code> for the default.
      * @param orderField The field used to order the results by. Use <code>null</code> for the default.
      * @param orderDirection The direction to order the results by. Use <code>null</code> for the default.
@@ -516,7 +516,7 @@ public class Lists extends CreateSendBase {
 
     /**
      * Gets a paged collection of subscribers who have been deleted from the list.
-     * @param page the page number of results to get. Use <code>null</code> for the default (page=1)
+     * @param page The page number of results to get. Use <code>null</code> for the default (page=1)
      * @param pageSize The number of records to get on the current page. Use <code>null</code> for the default.
      * @param orderField The field used to order the results by. Use <code>null</code> for the default.
      * @param orderDirection The direction to order the results by. Use <code>null</code> for the default.
@@ -532,7 +532,7 @@ public class Lists extends CreateSendBase {
 
     /**
      * Gets a paged collection of subscribers who have been deleted from the list.
-     * @param page the page number of results to get. Use <code>null</code> for the default (page=1)
+     * @param page The page number of results to get. Use <code>null</code> for the default (page=1)
      * @param pageSize The number of records to get on the current page. Use <code>null</code> for the default.
      * @param orderField The field used to order the results by. Use <code>null</code> for the default.
      * @param orderDirection The direction to order the results by. Use <code>null</code> for the default.
@@ -551,7 +551,7 @@ public class Lists extends CreateSendBase {
      * Gets a paged collection of subscribers who have been deleted from the list 
      * since the provided date.
      * @param subscribedFrom The API will only return subscribers who were deleted on or after this date. 
-     * @param page the page number of results to get. Use <code>null</code> for the default (page=1)
+     * @param page The page number of results to get. Use <code>null</code> for the default (page=1)
      * @param pageSize The number of records to get on the current page. Use <code>null</code> for the default.
      * @param orderField The field used to order the results by. Use <code>null</code> for the default.
      * @param orderDirection The direction to order the results by. Use <code>null</code> for the default.
@@ -570,7 +570,7 @@ public class Lists extends CreateSendBase {
      * Gets a paged collection of subscribers who have been deleted from the list
      * since the provided date.
      * @param subscribedFrom The API will only return subscribers who were deleted on or after this date.
-     * @param page the page number of results to get. Use <code>null</code> for the default (page=1)
+     * @param page The page number of results to get. Use <code>null</code> for the default (page=1)
      * @param pageSize The number of records to get on the current page. Use <code>null</code> for the default.
      * @param orderField The field used to order the results by. Use <code>null</code> for the default.
      * @param orderDirection The direction to order the results by. Use <code>null</code> for the default.
@@ -621,7 +621,7 @@ public class Lists extends CreateSendBase {
 
     /**
      * Gets a paged collection of bounced subscribers who have bounced out of the list.
-     * @param page the page number of results to get. Use <code>null</code> for the default (page=1)
+     * @param page The page number of results to get. Use <code>null</code> for the default (page=1)
      * @param pageSize The number of records to get on the current page. Use <code>null</code> for the default.
      * @param orderField The field used to order the results by. Use <code>null</code> for the default.
      * @param orderDirection The direction to order the results by. Use <code>null</code> for the default.
@@ -637,7 +637,7 @@ public class Lists extends CreateSendBase {
 
     /**
      * Gets a paged collection of bounced subscribers who have bounced out of the list.
-     * @param page the page number of results to get. Use <code>null</code> for the default (page=1)
+     * @param page The page number of results to get. Use <code>null</code> for the default (page=1)
      * @param pageSize The number of records to get on the current page. Use <code>null</code> for the default.
      * @param orderField The field used to order the results by. Use <code>null</code> for the default.
      * @param orderDirection The direction to order the results by. Use <code>null</code> for the default.
@@ -656,7 +656,7 @@ public class Lists extends CreateSendBase {
      * Gets a paged collection of bounced subscribers who have bounced out of the list 
      * since the provided date.
      * @param subscribedFrom The API will only return subscribers who bounced out on or after this date. 
-     * @param page the page number of results to get. Use <code>null</code> for the default (page=1)
+     * @param page The page number of results to get. Use <code>null</code> for the default (page=1)
      * @param pageSize The number of records to get on the current page. Use <code>null</code> for the default.
      * @param orderField The field used to order the results by. Use <code>null</code> for the default.
      * @param orderDirection The direction to order the results by. Use <code>null</code> for the default.
@@ -675,7 +675,7 @@ public class Lists extends CreateSendBase {
      * Gets a paged collection of bounced subscribers who have bounced out of the list
      * since the provided date.
      * @param subscribedFrom The API will only return subscribers who bounced out on or after this date.
-     * @param page the page number of results to get. Use <code>null</code> for the default (page=1)
+     * @param page The page number of results to get. Use <code>null</code> for the default (page=1)
      * @param pageSize The number of records to get on the current page. Use <code>null</code> for the default.
      * @param orderField The field used to order the results by. Use <code>null</code> for the default.
      * @param orderDirection The direction to order the results by. Use <code>null</code> for the default.

--- a/src/com/createsend/Lists.java
+++ b/src/com/createsend/Lists.java
@@ -195,7 +195,7 @@ public class Lists extends CreateSendBase {
 
     /**
      * Gets a paged collection of active subscribers who have subscribed to the list.
-     * @param page The page number or results to get. Use <code>null</code> for the default (page=1)
+     * @param page the page number of results to get. Use <code>null</code> for the default (page=1)
      * @param pageSize The number of records to get on the current page. Use <code>null</code> for the default.
      * @param orderField The field used to order the results by. Use <code>null</code> for the default.
      * @param orderDirection The direction to order the results by. Use <code>null</code> for the default.
@@ -211,7 +211,7 @@ public class Lists extends CreateSendBase {
 
     /**
      * Gets a paged collection of active subscribers who have subscribed to the list.
-     * @param page The page number or results to get. Use <code>null</code> for the default (page=1)
+     * @param page the page number of results to get. Use <code>null</code> for the default (page=1)
      * @param pageSize The number of records to get on the current page. Use <code>null</code> for the default.
      * @param orderField The field used to order the results by. Use <code>null</code> for the default.
      * @param orderDirection The direction to order the results by. Use <code>null</code> for the default.
@@ -231,7 +231,7 @@ public class Lists extends CreateSendBase {
      * since the provided date.
      * @param subscribedFrom The API will only return subscribers who became active on or after this date. 
      *     This field is required
-     * @param page The page number or results to get. Use <code>null</code> for the default (page=1)
+     * @param page the page number of results to get. Use <code>null</code> for the default (page=1)
      * @param pageSize The number of records to get on the current page. Use <code>null</code> for the default.
      * @param orderField The field used to order the results by. Use <code>null</code> for the default.
      * @param orderDirection The direction to order the results by. Use <code>null</code> for the default.
@@ -251,7 +251,7 @@ public class Lists extends CreateSendBase {
      * since the provided date.
      * @param subscribedFrom The API will only return subscribers who became active on or after this date.
      *     This field is required
-     * @param page The page number or results to get. Use <code>null</code> for the default (page=1)
+     * @param page the page number of results to get. Use <code>null</code> for the default (page=1)
      * @param pageSize The number of records to get on the current page. Use <code>null</code> for the default.
      * @param orderField The field used to order the results by. Use <code>null</code> for the default.
      * @param orderDirection The direction to order the results by. Use <code>null</code> for the default.
@@ -302,7 +302,7 @@ public class Lists extends CreateSendBase {
 
     /**
      * Gets a paged collection of unconfirmed subscribers who have subscribed to the list.
-     * @param page The page number or results to get. Use <code>null</code> for the default (page=1)
+     * @param page the page number of results to get. Use <code>null</code> for the default (page=1)
      * @param pageSize The number of records to get on the current page. Use <code>null</code> for the default.
      * @param orderField The field used to order the results by. Use <code>null</code> for the default.
      * @param orderDirection The direction to order the results by. Use <code>null</code> for the default.
@@ -318,7 +318,7 @@ public class Lists extends CreateSendBase {
 
     /**
      * Gets a paged collection of unconfirmed subscribers who have subscribed to the list.
-     * @param page The page number or results to get. Use <code>null</code> for the default (page=1)
+     * @param page the page number of results to get. Use <code>null</code> for the default (page=1)
      * @param pageSize The number of records to get on the current page. Use <code>null</code> for the default.
      * @param orderField The field used to order the results by. Use <code>null</code> for the default.
      * @param orderDirection The direction to order the results by. Use <code>null</code> for the default.
@@ -338,7 +338,7 @@ public class Lists extends CreateSendBase {
      * since the provided date.
      * @param subscribedFrom The API will only return subscribers who subscribed on or after this date. 
      *     This field is required
-     * @param page The page number or results to get. Use <code>null</code> for the default (page=1)
+     * @param page the page number of results to get. Use <code>null</code> for the default (page=1)
      * @param pageSize The number of records to get on the current page. Use <code>null</code> for the default.
      * @param orderField The field used to order the results by. Use <code>null</code> for the default.
      * @param orderDirection The direction to order the results by. Use <code>null</code> for the default.
@@ -358,7 +358,7 @@ public class Lists extends CreateSendBase {
      * since the provided date.
      * @param subscribedFrom The API will only return subscribers who subscribed on or after this date.
      *     This field is required
-     * @param page The page number or results to get. Use <code>null</code> for the default (page=1)
+     * @param page the page number of results to get. Use <code>null</code> for the default (page=1)
      * @param pageSize The number of records to get on the current page. Use <code>null</code> for the default.
      * @param orderField The field used to order the results by. Use <code>null</code> for the default.
      * @param orderDirection The direction to order the results by. Use <code>null</code> for the default.
@@ -410,7 +410,7 @@ public class Lists extends CreateSendBase {
 
     /**
      * Gets a paged collection of unsubscribed subscribers who have unsubscribed from the list.
-     * @param page The page number or results to get. Use <code>null</code> for the default (page=1)
+     * @param page the page number of results to get. Use <code>null</code> for the default (page=1)
      * @param pageSize The number of records to get on the current page. Use <code>null</code> for the default.
      * @param orderField The field used to order the results by. Use <code>null</code> for the default.
      * @param orderDirection The direction to order the results by. Use <code>null</code> for the default.
@@ -426,7 +426,7 @@ public class Lists extends CreateSendBase {
 
     /**
      * Gets a paged collection of unsubscribed subscribers who have unsubscribed from the list.
-     * @param page The page number or results to get. Use <code>null</code> for the default (page=1)
+     * @param page the page number of results to get. Use <code>null</code> for the default (page=1)
      * @param pageSize The number of records to get on the current page. Use <code>null</code> for the default.
      * @param orderField The field used to order the results by. Use <code>null</code> for the default.
      * @param orderDirection The direction to order the results by. Use <code>null</code> for the default.
@@ -445,7 +445,7 @@ public class Lists extends CreateSendBase {
      * Gets a paged collection of unsubscribed subscribers who have unsubscribed from the list 
      * since the provided date.
      * @param subscribedFrom The API will only return subscribers who unsubscribed on or after this date. 
-     * @param page The page number or results to get. Use <code>null</code> for the default (page=1)
+     * @param page the page number of results to get. Use <code>null</code> for the default (page=1)
      * @param pageSize The number of records to get on the current page. Use <code>null</code> for the default.
      * @param orderField The field used to order the results by. Use <code>null</code> for the default.
      * @param orderDirection The direction to order the results by. Use <code>null</code> for the default.
@@ -464,7 +464,7 @@ public class Lists extends CreateSendBase {
      * Gets a paged collection of unsubscribed subscribers who have unsubscribed from the list
      * since the provided date.
      * @param subscribedFrom The API will only return subscribers who unsubscribed on or after this date.
-     * @param page The page number or results to get. Use <code>null</code> for the default (page=1)
+     * @param page the page number of results to get. Use <code>null</code> for the default (page=1)
      * @param pageSize The number of records to get on the current page. Use <code>null</code> for the default.
      * @param orderField The field used to order the results by. Use <code>null</code> for the default.
      * @param orderDirection The direction to order the results by. Use <code>null</code> for the default.
@@ -516,7 +516,7 @@ public class Lists extends CreateSendBase {
 
     /**
      * Gets a paged collection of subscribers who have been deleted from the list.
-     * @param page The page number or results to get. Use <code>null</code> for the default (page=1)
+     * @param page the page number of results to get. Use <code>null</code> for the default (page=1)
      * @param pageSize The number of records to get on the current page. Use <code>null</code> for the default.
      * @param orderField The field used to order the results by. Use <code>null</code> for the default.
      * @param orderDirection The direction to order the results by. Use <code>null</code> for the default.
@@ -532,7 +532,7 @@ public class Lists extends CreateSendBase {
 
     /**
      * Gets a paged collection of subscribers who have been deleted from the list.
-     * @param page The page number or results to get. Use <code>null</code> for the default (page=1)
+     * @param page the page number of results to get. Use <code>null</code> for the default (page=1)
      * @param pageSize The number of records to get on the current page. Use <code>null</code> for the default.
      * @param orderField The field used to order the results by. Use <code>null</code> for the default.
      * @param orderDirection The direction to order the results by. Use <code>null</code> for the default.
@@ -551,7 +551,7 @@ public class Lists extends CreateSendBase {
      * Gets a paged collection of subscribers who have been deleted from the list 
      * since the provided date.
      * @param subscribedFrom The API will only return subscribers who were deleted on or after this date. 
-     * @param page The page number or results to get. Use <code>null</code> for the default (page=1)
+     * @param page the page number of results to get. Use <code>null</code> for the default (page=1)
      * @param pageSize The number of records to get on the current page. Use <code>null</code> for the default.
      * @param orderField The field used to order the results by. Use <code>null</code> for the default.
      * @param orderDirection The direction to order the results by. Use <code>null</code> for the default.
@@ -570,7 +570,7 @@ public class Lists extends CreateSendBase {
      * Gets a paged collection of subscribers who have been deleted from the list
      * since the provided date.
      * @param subscribedFrom The API will only return subscribers who were deleted on or after this date.
-     * @param page The page number or results to get. Use <code>null</code> for the default (page=1)
+     * @param page the page number of results to get. Use <code>null</code> for the default (page=1)
      * @param pageSize The number of records to get on the current page. Use <code>null</code> for the default.
      * @param orderField The field used to order the results by. Use <code>null</code> for the default.
      * @param orderDirection The direction to order the results by. Use <code>null</code> for the default.
@@ -621,7 +621,7 @@ public class Lists extends CreateSendBase {
 
     /**
      * Gets a paged collection of bounced subscribers who have bounced out of the list.
-     * @param page The page number or results to get. Use <code>null</code> for the default (page=1)
+     * @param page the page number of results to get. Use <code>null</code> for the default (page=1)
      * @param pageSize The number of records to get on the current page. Use <code>null</code> for the default.
      * @param orderField The field used to order the results by. Use <code>null</code> for the default.
      * @param orderDirection The direction to order the results by. Use <code>null</code> for the default.
@@ -637,7 +637,7 @@ public class Lists extends CreateSendBase {
 
     /**
      * Gets a paged collection of bounced subscribers who have bounced out of the list.
-     * @param page The page number or results to get. Use <code>null</code> for the default (page=1)
+     * @param page the page number of results to get. Use <code>null</code> for the default (page=1)
      * @param pageSize The number of records to get on the current page. Use <code>null</code> for the default.
      * @param orderField The field used to order the results by. Use <code>null</code> for the default.
      * @param orderDirection The direction to order the results by. Use <code>null</code> for the default.
@@ -656,7 +656,7 @@ public class Lists extends CreateSendBase {
      * Gets a paged collection of bounced subscribers who have bounced out of the list 
      * since the provided date.
      * @param subscribedFrom The API will only return subscribers who bounced out on or after this date. 
-     * @param page The page number or results to get. Use <code>null</code> for the default (page=1)
+     * @param page the page number of results to get. Use <code>null</code> for the default (page=1)
      * @param pageSize The number of records to get on the current page. Use <code>null</code> for the default.
      * @param orderField The field used to order the results by. Use <code>null</code> for the default.
      * @param orderDirection The direction to order the results by. Use <code>null</code> for the default.
@@ -675,7 +675,7 @@ public class Lists extends CreateSendBase {
      * Gets a paged collection of bounced subscribers who have bounced out of the list
      * since the provided date.
      * @param subscribedFrom The API will only return subscribers who bounced out on or after this date.
-     * @param page The page number or results to get. Use <code>null</code> for the default (page=1)
+     * @param page the page number of results to get. Use <code>null</code> for the default (page=1)
      * @param pageSize The number of records to get on the current page. Use <code>null</code> for the default.
      * @param orderField The field used to order the results by. Use <code>null</code> for the default.
      * @param orderDirection The direction to order the results by. Use <code>null</code> for the default.

--- a/src/com/createsend/Lists.java
+++ b/src/com/createsend/Lists.java
@@ -21,10 +21,6 @@
  */
 package com.createsend;
 
-import java.util.Date;
-
-import javax.ws.rs.core.MultivaluedMap;
-
 import com.createsend.models.PagedResult;
 import com.createsend.models.lists.CustomField;
 import com.createsend.models.lists.CustomFieldForCreate;
@@ -36,13 +32,16 @@ import com.createsend.models.lists.UpdateFieldOptions;
 import com.createsend.models.lists.Webhook;
 import com.createsend.models.lists.WebhookTestFailureDetails;
 import com.createsend.models.segments.Segment;
-import com.createsend.models.subscribers.Subscriber;
+import com.createsend.models.subscribers.SubscriberWithJoinedDate;
 import com.createsend.util.AuthenticationDetails;
 import com.createsend.util.ErrorDeserialiser;
 import com.createsend.util.JerseyClientImpl;
 import com.createsend.util.exceptions.CreateSendException;
 import com.createsend.util.jersey.JsonProvider;
 import com.sun.jersey.core.util.MultivaluedMapImpl;
+
+import javax.ws.rs.core.MultivaluedMap;
+import java.util.Date;
 
 /**
  * Provides methods for accessing all <a href="http://www.campaignmonitor.com/api/lists/" target="_blank">
@@ -177,7 +176,7 @@ public class Lists extends CreateSendBase {
      * @see <a href="https://www.campaignmonitor.com/api/lists/#active-subscribers" target="_blank">
      * Getting active subscribers</a>
      */
-    public PagedResult<Subscriber> active() throws CreateSendException {
+    public PagedResult<SubscriberWithJoinedDate> active() throws CreateSendException {
         return active(1, 1000, "email", "asc", false);
     }
 
@@ -189,7 +188,7 @@ public class Lists extends CreateSendBase {
      * @see <a href="https://www.campaignmonitor.com/api/lists/#active-subscribers" target="_blank">
      * Getting active subscribers</a>
      */
-    public PagedResult<Subscriber> active(boolean includeTrackingPreference) throws CreateSendException {
+    public PagedResult<SubscriberWithJoinedDate> active(boolean includeTrackingPreference) throws CreateSendException {
         return active(1, 1000, "email", "asc", includeTrackingPreference);
     }
 
@@ -204,7 +203,7 @@ public class Lists extends CreateSendBase {
      * @see <a href="https://www.campaignmonitor.com/api/lists/#active-subscribers" target="_blank">
      * Getting active subscribers</a>
      */
-    public PagedResult<Subscriber> active(Integer page, Integer pageSize,
+    public PagedResult<SubscriberWithJoinedDate> active(Integer page, Integer pageSize,
         String orderField, String orderDirection) throws CreateSendException {
         return active("", page, pageSize, orderField, orderDirection, false);
     }
@@ -221,7 +220,7 @@ public class Lists extends CreateSendBase {
      * @see <a href="https://www.campaignmonitor.com/api/lists/#active-subscribers" target="_blank">
      * Getting active subscribers</a>
      */
-    public PagedResult<Subscriber> active(Integer page, Integer pageSize, String orderField,
+    public PagedResult<SubscriberWithJoinedDate> active(Integer page, Integer pageSize, String orderField,
         String orderDirection, boolean includeTrackingPreference) throws CreateSendException {
         return active("", page, pageSize, orderField, orderDirection, includeTrackingPreference);
     }
@@ -240,7 +239,7 @@ public class Lists extends CreateSendBase {
      * @see <a href="https://www.campaignmonitor.com/api/lists/#active-subscribers" target="_blank">
      * Getting active subscribers</a>
      */
-    public PagedResult<Subscriber> active(Date subscribedFrom, Integer page, Integer pageSize,
+    public PagedResult<SubscriberWithJoinedDate> active(Date subscribedFrom, Integer page, Integer pageSize,
         String orderField, String orderDirection) throws CreateSendException {
         return active(JsonProvider.ApiDateFormat.format(subscribedFrom),
                 page, pageSize, orderField, orderDirection, false);
@@ -261,13 +260,13 @@ public class Lists extends CreateSendBase {
      * @see <a href="https://www.campaignmonitor.com/api/lists/#active-subscribers" target="_blank">
      * Getting active subscribers</a>
      */
-    public PagedResult<Subscriber> active(Date subscribedFrom, Integer page, Integer pageSize,
+    public PagedResult<SubscriberWithJoinedDate> active(Date subscribedFrom, Integer page, Integer pageSize,
         String orderField, String orderDirection, boolean includeTrackingPreference) throws CreateSendException {
         return active(JsonProvider.ApiDateFormat.format(subscribedFrom),
             page, pageSize, orderField, orderDirection, includeTrackingPreference);
     }
     
-    private PagedResult<Subscriber> active(String subscribedFrom, Integer page, Integer pageSize,
+    private PagedResult<SubscriberWithJoinedDate> active(String subscribedFrom, Integer page, Integer pageSize,
         String orderField, String orderDirection, boolean includeTrackingPreference) throws CreateSendException {
         MultivaluedMap<String, String> queryString = new MultivaluedMapImpl(); 
         queryString.add("date", subscribedFrom);
@@ -284,7 +283,7 @@ public class Lists extends CreateSendBase {
      * @see <a href="https://www.campaignmonitor.com/api/lists/#unconfirmed-subscribers" target="_blank">
      * Getting active subscribers</a>
      */
-    public PagedResult<Subscriber> unconfirmed() throws CreateSendException {
+    public PagedResult<SubscriberWithJoinedDate> unconfirmed() throws CreateSendException {
         return unconfirmed(1, 1000, "email", "asc", false);
     }
 
@@ -296,7 +295,7 @@ public class Lists extends CreateSendBase {
      * @see <a href="https://www.campaignmonitor.com/api/lists/#unconfirmed-subscribers" target="_blank">
      * Getting active subscribers</a>
      */
-    public PagedResult<Subscriber> unconfirmed(boolean includeTrackingPreference) throws CreateSendException {
+    public PagedResult<SubscriberWithJoinedDate> unconfirmed(boolean includeTrackingPreference) throws CreateSendException {
         return unconfirmed(1, 1000, "email", "asc", includeTrackingPreference);
     }
 
@@ -311,7 +310,7 @@ public class Lists extends CreateSendBase {
      * @see <a href="https://www.campaignmonitor.com/api/lists/#unconfirmed-subscribers" target="_blank">
      * Getting active subscribers</a>
      */
-    public PagedResult<Subscriber> unconfirmed(Integer page, Integer pageSize,
+    public PagedResult<SubscriberWithJoinedDate> unconfirmed(Integer page, Integer pageSize,
         String orderField, String orderDirection) throws CreateSendException {
         return unconfirmed("", page, pageSize, orderField, orderDirection, false);
     }
@@ -328,7 +327,7 @@ public class Lists extends CreateSendBase {
      * @see <a href="https://www.campaignmonitor.com/api/lists/#unconfirmed-subscribers" target="_blank">
      * Getting active subscribers</a>
      */
-    public PagedResult<Subscriber> unconfirmed(Integer page, Integer pageSize, String orderField,
+    public PagedResult<SubscriberWithJoinedDate> unconfirmed(Integer page, Integer pageSize, String orderField,
         String orderDirection, boolean includeTrackingPreference) throws CreateSendException {
         return unconfirmed("", page, pageSize, orderField, orderDirection, includeTrackingPreference);
     }
@@ -347,7 +346,7 @@ public class Lists extends CreateSendBase {
      * @see <a href="https://www.campaignmonitor.com/api/lists/#unconfirmed-subscribers" target="_blank">
      * Getting active subscribers</a>
      */
-    public PagedResult<Subscriber> unconfirmed(Date subscribedFrom, Integer page, Integer pageSize,
+    public PagedResult<SubscriberWithJoinedDate> unconfirmed(Date subscribedFrom, Integer page, Integer pageSize,
         String orderField, String orderDirection) throws CreateSendException {
         return unconfirmed(JsonProvider.ApiDateFormat.format(subscribedFrom),
                 page, pageSize, orderField, orderDirection, false);
@@ -368,13 +367,13 @@ public class Lists extends CreateSendBase {
      * @see <a href="https://www.campaignmonitor.com/api/lists/#unconfirmed-subscribers" target="_blank">
      * Getting active subscribers</a>
      */
-    public PagedResult<Subscriber> unconfirmed(Date subscribedFrom, Integer page, Integer pageSize,
+    public PagedResult<SubscriberWithJoinedDate> unconfirmed(Date subscribedFrom, Integer page, Integer pageSize,
         String orderField, String orderDirection, boolean includeTrackingPreference) throws CreateSendException {
         return unconfirmed(JsonProvider.ApiDateFormat.format(subscribedFrom),
             page, pageSize, orderField, orderDirection, includeTrackingPreference);
     }
     
-    private PagedResult<Subscriber> unconfirmed(String subscribedFrom, Integer page,
+    private PagedResult<SubscriberWithJoinedDate> unconfirmed(String subscribedFrom, Integer page,
         Integer pageSize, String orderField, String orderDirection, boolean includeTrackingPreference) throws CreateSendException {
         MultivaluedMap<String, String> queryString = new MultivaluedMapImpl(); 
         queryString.add("date", subscribedFrom);
@@ -391,7 +390,7 @@ public class Lists extends CreateSendBase {
      * @see <a href="https://www.campaignmonitor.com/api/lists/#unsubscribed-subscribers" target="_blank">
      * Getting unsubscribed subscribers</a>
      */
-    public PagedResult<Subscriber> unsubscribed() throws CreateSendException {
+    public PagedResult<SubscriberWithJoinedDate> unsubscribed() throws CreateSendException {
         return unsubscribed(1, 1000, "email", "asc", false);
     }
 
@@ -403,7 +402,7 @@ public class Lists extends CreateSendBase {
      * @see <a href="https://www.campaignmonitor.com/api/lists/#unsubscribed-subscribers" target="_blank">
      * Getting unsubscribed subscribers</a>
      */
-    public PagedResult<Subscriber> unsubscribed(boolean includeTrackingPreference) throws CreateSendException {
+    public PagedResult<SubscriberWithJoinedDate> unsubscribed(boolean includeTrackingPreference) throws CreateSendException {
         return unsubscribed(1, 1000, "email", "asc", includeTrackingPreference);
     }
 
@@ -419,7 +418,7 @@ public class Lists extends CreateSendBase {
      * @see <a href="https://www.campaignmonitor.com/api/lists/#unsubscribed-subscribers" target="_blank">
      * Getting unsubscribed subscribers</a>
      */
-    public PagedResult<Subscriber> unsubscribed(Integer page, Integer pageSize,
+    public PagedResult<SubscriberWithJoinedDate> unsubscribed(Integer page, Integer pageSize,
         String orderField, String orderDirection) throws CreateSendException {
         return unsubscribed("", page, pageSize, orderField, orderDirection, false);
     }
@@ -436,7 +435,7 @@ public class Lists extends CreateSendBase {
      * @see <a href="https://www.campaignmonitor.com/api/lists/#unsubscribed-subscribers" target="_blank">
      * Getting unsubscribed subscribers</a>
      */
-    public PagedResult<Subscriber> unsubscribed(Integer page, Integer pageSize,
+    public PagedResult<SubscriberWithJoinedDate> unsubscribed(Integer page, Integer pageSize,
         String orderField, String orderDirection, boolean includeTrackingPreference) throws CreateSendException {
         return unsubscribed("", page, pageSize, orderField, orderDirection, includeTrackingPreference);
     }
@@ -454,7 +453,7 @@ public class Lists extends CreateSendBase {
      * @see <a href="https://www.campaignmonitor.com/api/lists/#unsubscribed-subscribers" target="_blank">
      * Getting unsubscribed subscribers</a>
      */
-    public PagedResult<Subscriber> unsubscribed(Date subscribedFrom, Integer page,
+    public PagedResult<SubscriberWithJoinedDate> unsubscribed(Date subscribedFrom, Integer page,
         Integer pageSize, String orderField, String orderDirection) throws CreateSendException {
         return unsubscribed(JsonProvider.ApiDateFormat.format(subscribedFrom),
                 page, pageSize, orderField, orderDirection, false);
@@ -474,14 +473,14 @@ public class Lists extends CreateSendBase {
      * @see <a href="https://www.campaignmonitor.com/api/lists/#unsubscribed-subscribers" target="_blank">
      * Getting unsubscribed subscribers</a>
      */
-    public PagedResult<Subscriber> unsubscribed(Date subscribedFrom, Integer page, Integer pageSize,
+    public PagedResult<SubscriberWithJoinedDate> unsubscribed(Date subscribedFrom, Integer page, Integer pageSize,
         String orderField, String orderDirection, boolean includeTrackingPreference) throws CreateSendException {
         return unsubscribed(JsonProvider.ApiDateFormat.format(subscribedFrom),
             page, pageSize, orderField, orderDirection, includeTrackingPreference);
     }
 
 
-    private PagedResult<Subscriber> unsubscribed(String subscribedFrom, Integer page, Integer pageSize,
+    private PagedResult<SubscriberWithJoinedDate> unsubscribed(String subscribedFrom, Integer page, Integer pageSize,
         String orderField, String orderDirection, boolean includeTrackingPreference) throws CreateSendException {
         MultivaluedMap<String, String> queryString = new MultivaluedMapImpl(); 
         queryString.add("date", subscribedFrom);
@@ -498,7 +497,7 @@ public class Lists extends CreateSendBase {
      * @see <a href="https://www.campaignmonitor.com/api/lists/#deleted-subscribers" target="_blank">
      * Getting deleted subscribers</a>
      */
-    public PagedResult<Subscriber> deleted() throws CreateSendException {
+    public PagedResult<SubscriberWithJoinedDate> deleted() throws CreateSendException {
         return deleted(1, 1000, "email", "asc", false);
     }
 
@@ -510,7 +509,7 @@ public class Lists extends CreateSendBase {
      * @see <a href="https://www.campaignmonitor.com/api/lists/#deleted-subscribers" target="_blank">
      * Getting deleted subscribers</a>
      */
-    public PagedResult<Subscriber> deleted(boolean includeTrackingPreference) throws CreateSendException {
+    public PagedResult<SubscriberWithJoinedDate> deleted(boolean includeTrackingPreference) throws CreateSendException {
         return deleted(1, 1000, "email", "asc", includeTrackingPreference);
     }
 
@@ -525,7 +524,7 @@ public class Lists extends CreateSendBase {
      * @see <a href="https://www.campaignmonitor.com/api/lists/#deleted-subscribers" target="_blank">
      * Getting deleted subscribers</a>
      */
-    public PagedResult<Subscriber> deleted(Integer page, Integer pageSize, String orderField,
+    public PagedResult<SubscriberWithJoinedDate> deleted(Integer page, Integer pageSize, String orderField,
         String orderDirection) throws CreateSendException {
         return deleted("", page, pageSize, orderField, orderDirection, false);
     }
@@ -542,7 +541,7 @@ public class Lists extends CreateSendBase {
      * @see <a href="https://www.campaignmonitor.com/api/lists/#deleted-subscribers" target="_blank">
      * Getting deleted subscribers</a>
      */
-    public PagedResult<Subscriber> deleted(Integer page, Integer pageSize, String orderField,
+    public PagedResult<SubscriberWithJoinedDate> deleted(Integer page, Integer pageSize, String orderField,
         String orderDirection, boolean includeTrackingPreference) throws CreateSendException {
         return deleted("", page, pageSize, orderField, orderDirection, includeTrackingPreference);
     }
@@ -560,7 +559,7 @@ public class Lists extends CreateSendBase {
      * @see <a href="https://www.campaignmonitor.com/api/lists/#deleted-subscribers" target="_blank">
      * Getting deleted subscribers</a>
      */
-    public PagedResult<Subscriber> deleted(Date subscribedFrom,Integer page, Integer pageSize,
+    public PagedResult<SubscriberWithJoinedDate> deleted(Date subscribedFrom,Integer page, Integer pageSize,
         String orderField, String orderDirection) throws CreateSendException {
         return deleted(JsonProvider.ApiDateFormat.format(subscribedFrom),
                 page, pageSize, orderField, orderDirection, false);
@@ -580,13 +579,13 @@ public class Lists extends CreateSendBase {
      * @see <a href="https://www.campaignmonitor.com/api/lists/#deleted-subscribers" target="_blank">
      * Getting deleted subscribers</a>
      */
-    public PagedResult<Subscriber> deleted(Date subscribedFrom, Integer page, Integer pageSize,
+    public PagedResult<SubscriberWithJoinedDate> deleted(Date subscribedFrom, Integer page, Integer pageSize,
         String orderField, String orderDirection, boolean includeTrackingPreference) throws CreateSendException {
         return deleted(JsonProvider.ApiDateFormat.format(subscribedFrom),
             page, pageSize, orderField, orderDirection, includeTrackingPreference);
     }
     
-    private PagedResult<Subscriber> deleted(String subscribedFrom, Integer page, Integer pageSize,
+    private PagedResult<SubscriberWithJoinedDate> deleted(String subscribedFrom, Integer page, Integer pageSize,
         String orderField, String orderDirection, boolean includeTrackingPreference) throws CreateSendException {
         MultivaluedMap<String, String> queryString = new MultivaluedMapImpl(); 
         queryString.add("date", subscribedFrom);
@@ -603,7 +602,7 @@ public class Lists extends CreateSendBase {
      * @see <a href="https://www.campaignmonitor.com/api/lists/#bounced-subscribers" target="_blank">
      * Getting bounced subscribers</a>
      */
-    public PagedResult<Subscriber> bounced() throws CreateSendException {
+    public PagedResult<SubscriberWithJoinedDate> bounced() throws CreateSendException {
         return bounced(1, 1000, "email", "asc", false);
     }
 
@@ -615,7 +614,7 @@ public class Lists extends CreateSendBase {
      * @see <a href="https://www.campaignmonitor.com/api/lists/#bounced-subscribers" target="_blank">
      * Getting bounced subscribers</a>
      */
-    public PagedResult<Subscriber> bounced(boolean includeTrackingPreference) throws CreateSendException {
+    public PagedResult<SubscriberWithJoinedDate> bounced(boolean includeTrackingPreference) throws CreateSendException {
         return bounced(1, 1000, "email", "asc", includeTrackingPreference);
     }
 
@@ -630,7 +629,7 @@ public class Lists extends CreateSendBase {
      * @see <a href="https://www.campaignmonitor.com/api/lists/#bounced-subscribers" target="_blank">
      * Getting bounced subscribers</a>
      */
-    public PagedResult<Subscriber> bounced(Integer page, Integer pageSize,
+    public PagedResult<SubscriberWithJoinedDate> bounced(Integer page, Integer pageSize,
         String orderField, String orderDirection) throws CreateSendException {
         return bounced("", page, pageSize, orderField, orderDirection, false);
     }
@@ -647,7 +646,7 @@ public class Lists extends CreateSendBase {
      * @see <a href="https://www.campaignmonitor.com/api/lists/#bounced-subscribers" target="_blank">
      * Getting bounced subscribers</a>
      */
-    public PagedResult<Subscriber> bounced(Integer page, Integer pageSize, String orderField,
+    public PagedResult<SubscriberWithJoinedDate> bounced(Integer page, Integer pageSize, String orderField,
         String orderDirection, boolean includeTrackingPreference) throws CreateSendException {
         return bounced("", page, pageSize, orderField, orderDirection, includeTrackingPreference);
     }
@@ -665,7 +664,7 @@ public class Lists extends CreateSendBase {
      * @see <a href="https://www.campaignmonitor.com/api/lists/#bounced-subscribers" target="_blank">
      * Getting bounced subscribers</a>
      */
-    public PagedResult<Subscriber> bounced(Date subscribedFrom, Integer page,
+    public PagedResult<SubscriberWithJoinedDate> bounced(Date subscribedFrom, Integer page,
         Integer pageSize, String orderField, String orderDirection) throws CreateSendException {
         return bounced(JsonProvider.ApiDateFormat.format(subscribedFrom),
                 page, pageSize, orderField, orderDirection, false);
@@ -685,13 +684,13 @@ public class Lists extends CreateSendBase {
      * @see <a href="https://www.campaignmonitor.com/api/lists/#bounced-subscribers" target="_blank">
      * Getting bounced subscribers</a>
      */
-    public PagedResult<Subscriber> bounced(Date subscribedFrom, Integer page, Integer pageSize,
+    public PagedResult<SubscriberWithJoinedDate> bounced(Date subscribedFrom, Integer page, Integer pageSize,
         String orderField, String orderDirection, boolean includeTrackingPreference) throws CreateSendException {
         return bounced(JsonProvider.ApiDateFormat.format(subscribedFrom),
             page, pageSize, orderField, orderDirection, includeTrackingPreference);
     }
 
-    private PagedResult<Subscriber> bounced(String subscribedFrom, Integer page, Integer pageSize,
+    private PagedResult<SubscriberWithJoinedDate> bounced(String subscribedFrom, Integer page, Integer pageSize,
         String orderField, String orderDirection, boolean includeTrackingPreference) throws CreateSendException {
         MultivaluedMap<String, String> queryString = new MultivaluedMapImpl(); 
         queryString.add("date", subscribedFrom);

--- a/src/com/createsend/Segments.java
+++ b/src/com/createsend/Segments.java
@@ -21,19 +21,21 @@
  */
 package com.createsend;
 
-import java.util.Date;
-
-import javax.ws.rs.core.MultivaluedMap;
-
 import com.createsend.models.PagedResult;
-import com.createsend.models.segments.*;
-import com.createsend.models.subscribers.Subscriber;
+import com.createsend.models.segments.ClauseResults;
+import com.createsend.models.segments.RuleCreationFailureDetails;
+import com.createsend.models.segments.RuleGroup;
+import com.createsend.models.segments.Segment;
+import com.createsend.models.subscribers.SubscriberWithJoinedDate;
 import com.createsend.util.AuthenticationDetails;
 import com.createsend.util.ErrorDeserialiser;
 import com.createsend.util.JerseyClientImpl;
 import com.createsend.util.exceptions.CreateSendException;
 import com.createsend.util.jersey.JsonProvider;
 import com.sun.jersey.core.util.MultivaluedMapImpl;
+
+import javax.ws.rs.core.MultivaluedMap;
+import java.util.Date;
 
 /**
  * Provides methods for accessing all <a href="http://www.campaignmonitor.com/api/segments/" target="_blank">
@@ -141,7 +143,7 @@ public class Segments extends CreateSendBase {
      * @see <a href="http://www.campaignmonitor.com/api/segments/#getting-active-subscribers" target="_blank">
      * Getting active subscribers</a>
      */
-    public PagedResult<Subscriber> active() throws CreateSendException {
+    public PagedResult<SubscriberWithJoinedDate> active() throws CreateSendException {
     	return active(1, 1000, "email", "asc", false);
     }
 
@@ -153,7 +155,7 @@ public class Segments extends CreateSendBase {
      * @see <a href="http://www.campaignmonitor.com/api/segments/#getting-active-subscribers" target="_blank">
      * Getting active subscribers</a>
      */
-    public PagedResult<Subscriber> active(boolean includeTrackingPreference) throws CreateSendException {
+    public PagedResult<SubscriberWithJoinedDate> active(boolean includeTrackingPreference) throws CreateSendException {
         return active(1, 1000, "email", "asc", includeTrackingPreference);
     }
 
@@ -168,7 +170,7 @@ public class Segments extends CreateSendBase {
      * @see <a href="http://www.campaignmonitor.com/api/segments/#getting-active-subscribers" target="_blank">
      * Getting active subscribers</a>
      */
-    public PagedResult<Subscriber> active(Integer page, Integer pageSize,
+    public PagedResult<SubscriberWithJoinedDate> active(Integer page, Integer pageSize,
         String orderField, String orderDirection) throws CreateSendException {
     	return active("", page, pageSize, orderField, orderDirection, false);
     }
@@ -185,7 +187,7 @@ public class Segments extends CreateSendBase {
      * @see <a href="http://www.campaignmonitor.com/api/segments/#getting-active-subscribers" target="_blank">
      * Getting active subscribers</a>
      */
-    public PagedResult<Subscriber> active(Integer page, Integer pageSize, String orderField,
+    public PagedResult<SubscriberWithJoinedDate> active(Integer page, Integer pageSize, String orderField,
         String orderDirection, boolean includeTrackingPreference) throws CreateSendException {
         return active("", page, pageSize, orderField, orderDirection, includeTrackingPreference);
     }
@@ -204,7 +206,7 @@ public class Segments extends CreateSendBase {
      * @see <a href="http://www.campaignmonitor.com/api/segments/#getting-active-subscribers" target="_blank">
      * Getting active subscribers</a>
      */
-    public PagedResult<Subscriber> active(Date subscribedFrom, Integer page, Integer pageSize,
+    public PagedResult<SubscriberWithJoinedDate> active(Date subscribedFrom, Integer page, Integer pageSize,
         String orderField, String orderDirection) throws CreateSendException {
     	return active(JsonProvider.ApiDateFormat.format(subscribedFrom),
     			page, pageSize, orderField, orderDirection, false);
@@ -225,13 +227,13 @@ public class Segments extends CreateSendBase {
      * @see <a href="http://www.campaignmonitor.com/api/segments/#getting-active-subscribers" target="_blank">
      * Getting active subscribers</a>
      */
-    public PagedResult<Subscriber> active(Date subscribedFrom, Integer page, Integer pageSize,
+    public PagedResult<SubscriberWithJoinedDate> active(Date subscribedFrom, Integer page, Integer pageSize,
         String orderField, String orderDirection, boolean includeTrackingPreference) throws CreateSendException {
         return active(JsonProvider.ApiDateFormat.format(subscribedFrom),
             page, pageSize, orderField, orderDirection, includeTrackingPreference);
     }
 
-    private PagedResult<Subscriber> active(String subscribedFrom, Integer page, Integer pageSize,
+    private PagedResult<SubscriberWithJoinedDate> active(String subscribedFrom, Integer page, Integer pageSize,
         String orderField, String orderDirection, boolean includeTrackingPreference) throws CreateSendException {
         MultivaluedMap<String, String> queryString = new MultivaluedMapImpl(); 
         queryString.add("date", subscribedFrom);

--- a/src/com/createsend/Segments.java
+++ b/src/com/createsend/Segments.java
@@ -159,7 +159,7 @@ public class Segments extends CreateSendBase {
 
     /**
      * Gets a paged collection of active subscribers within the specified segment.
-     * @param page the page number of results to get. Use <code>null</code> for the default (page=1)
+     * @param page The page number of results to get. Use <code>null</code> for the default (page=1)
      * @param pageSize The number of records to get on the current page. Use <code>null</code> for the default.
      * @param orderField The field used to order the results by. Use <code>null</code> for the default.
      * @param orderDirection The direction to order the results by. Use <code>null</code> for the default.
@@ -175,7 +175,7 @@ public class Segments extends CreateSendBase {
 
     /**
      * Gets a paged collection of active subscribers within the specified segment.
-     * @param page the page number of results to get. Use <code>null</code> for the default (page=1)
+     * @param page The page number of results to get. Use <code>null</code> for the default (page=1)
      * @param pageSize The number of records to get on the current page. Use <code>null</code> for the default.
      * @param orderField The field used to order the results by. Use <code>null</code> for the default.
      * @param orderDirection The direction to order the results by. Use <code>null</code> for the default.
@@ -195,7 +195,7 @@ public class Segments extends CreateSendBase {
      * since the provided date.
      * @param subscribedFrom The API will only return subscribers who became active on or after this date. 
      *     This field is required
-     * @param page the page number of results to get. Use <code>null</code> for the default (page=1)
+     * @param page The page number of results to get. Use <code>null</code> for the default (page=1)
      * @param pageSize The number of records to get on the current page. Use <code>null</code> for the default.
      * @param orderField The field used to order the results by. Use <code>null</code> for the default.
      * @param orderDirection The direction to order the results by. Use <code>null</code> for the default.
@@ -215,7 +215,7 @@ public class Segments extends CreateSendBase {
      * since the provided date.
      * @param subscribedFrom The API will only return subscribers who became active on or after this date.
      *     This field is required
-     * @param page the page number of results to get. Use <code>null</code> for the default (page=1)
+     * @param page The page number of results to get. Use <code>null</code> for the default (page=1)
      * @param pageSize The number of records to get on the current page. Use <code>null</code> for the default.
      * @param orderField The field used to order the results by. Use <code>null</code> for the default.
      * @param orderDirection The direction to order the results by. Use <code>null</code> for the default.

--- a/src/com/createsend/Segments.java
+++ b/src/com/createsend/Segments.java
@@ -159,7 +159,7 @@ public class Segments extends CreateSendBase {
 
     /**
      * Gets a paged collection of active subscribers within the specified segment.
-     * @param page The page number or results to get. Use <code>null</code> for the default (page=1)
+     * @param page the page number of results to get. Use <code>null</code> for the default (page=1)
      * @param pageSize The number of records to get on the current page. Use <code>null</code> for the default.
      * @param orderField The field used to order the results by. Use <code>null</code> for the default.
      * @param orderDirection The direction to order the results by. Use <code>null</code> for the default.
@@ -175,7 +175,7 @@ public class Segments extends CreateSendBase {
 
     /**
      * Gets a paged collection of active subscribers within the specified segment.
-     * @param page The page number or results to get. Use <code>null</code> for the default (page=1)
+     * @param page the page number of results to get. Use <code>null</code> for the default (page=1)
      * @param pageSize The number of records to get on the current page. Use <code>null</code> for the default.
      * @param orderField The field used to order the results by. Use <code>null</code> for the default.
      * @param orderDirection The direction to order the results by. Use <code>null</code> for the default.
@@ -195,7 +195,7 @@ public class Segments extends CreateSendBase {
      * since the provided date.
      * @param subscribedFrom The API will only return subscribers who became active on or after this date. 
      *     This field is required
-     * @param page The page number or results to get. Use <code>null</code> for the default (page=1)
+     * @param page the page number of results to get. Use <code>null</code> for the default (page=1)
      * @param pageSize The number of records to get on the current page. Use <code>null</code> for the default.
      * @param orderField The field used to order the results by. Use <code>null</code> for the default.
      * @param orderDirection The direction to order the results by. Use <code>null</code> for the default.
@@ -215,7 +215,7 @@ public class Segments extends CreateSendBase {
      * since the provided date.
      * @param subscribedFrom The API will only return subscribers who became active on or after this date.
      *     This field is required
-     * @param page The page number or results to get. Use <code>null</code> for the default (page=1)
+     * @param page the page number of results to get. Use <code>null</code> for the default (page=1)
      * @param pageSize The number of records to get on the current page. Use <code>null</code> for the default.
      * @param orderField The field used to order the results by. Use <code>null</code> for the default.
      * @param orderDirection The direction to order the results by. Use <code>null</code> for the default.

--- a/src/com/createsend/Subscribers.java
+++ b/src/com/createsend/Subscribers.java
@@ -21,19 +21,19 @@
  */
 package com.createsend;
 
-import javax.ws.rs.core.MultivaluedMap;
-
 import com.createsend.models.subscribers.EmailToUnsubscribe;
 import com.createsend.models.subscribers.HistoryItem;
 import com.createsend.models.subscribers.ImportResult;
-import com.createsend.models.subscribers.Subscriber;
 import com.createsend.models.subscribers.SubscriberToAdd;
+import com.createsend.models.subscribers.SubscriberWithJoinedDate;
 import com.createsend.models.subscribers.SubscribersToAdd;
 import com.createsend.util.AuthenticationDetails;
 import com.createsend.util.ErrorDeserialiser;
 import com.createsend.util.JerseyClientImpl;
 import com.createsend.util.exceptions.CreateSendException;
 import com.sun.jersey.core.util.MultivaluedMapImpl;
+
+import javax.ws.rs.core.MultivaluedMap;
 
 /**
  * Provides methods for accessing all <a href="http://www.campaignmonitor.com/api/subscribers/" target="_blank">
@@ -105,7 +105,7 @@ public class Subscribers extends CreateSendBase {
      * @see <a href="https://www.campaignmonitor.com/api/subscribers/#getting-subscribers-details" target="_blank">
      * Getting subscriber details</a>
      */
-    public Subscriber details(String emailAddress) throws CreateSendException {
+    public SubscriberWithJoinedDate details(String emailAddress) throws CreateSendException {
         return details(emailAddress, false);
     }
 
@@ -118,12 +118,12 @@ public class Subscribers extends CreateSendBase {
      * @see <a href="https://www.campaignmonitor.com/api/subscribers/#getting-subscribers-details" target="_blank">
      * Getting subscriber details</a>
      */
-    public Subscriber details(String emailAddress, boolean includeTrackingPreference) throws CreateSendException {
+    public SubscriberWithJoinedDate details(String emailAddress, boolean includeTrackingPreference) throws CreateSendException {
         MultivaluedMap<String, String> queryString = new MultivaluedMapImpl();
         queryString.add("email", emailAddress);
         queryString.add("includetrackingpreference", String.valueOf(includeTrackingPreference));
 
-        return jerseyClient.get(Subscriber.class, queryString, "subscribers", listID + ".json");
+        return jerseyClient.get(SubscriberWithJoinedDate.class, queryString, "subscribers", listID + ".json");
     }
     
     /**

--- a/src/com/createsend/models/campaigns/CampaignSummary.java
+++ b/src/com/createsend/models/campaigns/CampaignSummary.java
@@ -22,6 +22,7 @@
 package com.createsend.models.campaigns;
 
 public class CampaignSummary {
+    public String Name;
     public int Recipients;
     public int TotalOpened;
     public int Clicks;
@@ -39,7 +40,11 @@ public class CampaignSummary {
     @Override
     public String toString() {
         return String.format(
-            "{ Recipients: %s, TotalOpened: %s, Clicks: %s, Unsubscribed: %s, SpamComplaints: %s, Bounced: %s, UniqueOpened: %s, ForwardToAFriends: %s, TwitterTweets: %s, FacebookLikes: %s,  WebVersionURL: %s, WorldviewURL: %s }",
-            Recipients, TotalOpened, Clicks, Unsubscribed, SpamComplaints, Bounced, UniqueOpened, Forwards, Mentions, Likes, WebVersionURL, WorldviewURL);
+            "{ Name: %s, Recipients: %s, TotalOpened: %s, Clicks: %s, Unsubscribed: %s, SpamComplaints: %s, " +
+            "Bounced: %s, UniqueOpened: %s, ForwardToAFriends: %s, TwitterTweets: %s, FacebookLikes: %s, " +
+            "WebVersionURL: %s, WebVersionTextURL: %s, WorldviewURL: %s }",
+            Name, Recipients, TotalOpened, Clicks, Unsubscribed, SpamComplaints,
+            Bounced, UniqueOpened, Forwards, Mentions, Likes,
+            WebVersionURL, WebVersionTextURL, WorldviewURL);
     }
 }

--- a/src/com/createsend/models/campaigns/DraftCampaign.java
+++ b/src/com/createsend/models/campaigns/DraftCampaign.java
@@ -21,15 +21,19 @@
  */
 package com.createsend.models.campaigns;
 
+import java.util.Arrays;
 import java.util.Date;
 
 public class DraftCampaign extends Campaign {
     public Date DateCreated;
     public String PreviewURL;
     public String PreviewTextURL;
+    public String[] Tags;
     
     @Override
     public String toString() {
-        return String.format("{ %s, DateCreated: %s, PreviewURL: %s }", super.toString(), DateCreated, PreviewURL);
+        return String.format(
+            "{ %s, DateCreated: %s, PreviewURL: %s, PreviewTextURL: %s, Tags: %s }",
+            super.toString(), DateCreated, PreviewURL, PreviewTextURL, Arrays.toString(Tags));
     }
 }

--- a/src/com/createsend/models/campaigns/ScheduledCampaign.java
+++ b/src/com/createsend/models/campaigns/ScheduledCampaign.java
@@ -29,7 +29,8 @@ public class ScheduledCampaign extends DraftCampaign {
     
     @Override
     public String toString() {
-        return String.format("{ %s, DateScheduled: %s, ScheduledTimeZone: %s }", super.toString(), 
-                DateScheduled, ScheduledTimeZone);
+        return String.format(
+            "{ %s, DateScheduled: %s, ScheduledTimeZone: %s}",
+            super.toString(), DateScheduled, ScheduledTimeZone);
     }
 }

--- a/src/com/createsend/models/campaigns/SentCampaign.java
+++ b/src/com/createsend/models/campaigns/SentCampaign.java
@@ -29,12 +29,12 @@ public class SentCampaign extends Campaign {
     public String WebVersionTextURL;
     public Date SentDate;
     public int TotalRecipients;
-    public String[] Tags;
+    public String Tags;
     
     @Override
     public String toString() {
         return String.format(
             "{ %s, SendDate: %s, WebVersionURL: %s, WebVersionTextURL: %s, TotalRecipients: %d, Tags: %s }",
-            super.toString(), SentDate, WebVersionURL, WebVersionTextURL, TotalRecipients, Arrays.toString(Tags));
+            super.toString(), SentDate, WebVersionURL, WebVersionTextURL, TotalRecipients, Tags);
     }
 }

--- a/src/com/createsend/models/campaigns/SentCampaign.java
+++ b/src/com/createsend/models/campaigns/SentCampaign.java
@@ -29,12 +29,12 @@ public class SentCampaign extends Campaign {
     public String WebVersionTextURL;
     public Date SentDate;
     public int TotalRecipients;
-    public String Tags;
+    public String[] Tags;
     
     @Override
     public String toString() {
         return String.format(
             "{ %s, SendDate: %s, WebVersionURL: %s, WebVersionTextURL: %s, TotalRecipients: %d, Tags: %s }",
-            super.toString(), SentDate, WebVersionURL, WebVersionTextURL, TotalRecipients, Tags);
+            super.toString(), SentDate, WebVersionURL, WebVersionTextURL, TotalRecipients, Arrays.toString(Tags));
     }
 }

--- a/src/com/createsend/models/campaigns/SentCampaign.java
+++ b/src/com/createsend/models/campaigns/SentCampaign.java
@@ -21,6 +21,7 @@
  */
 package com.createsend.models.campaigns;
 
+import java.util.Arrays;
 import java.util.Date;
 
 public class SentCampaign extends Campaign {
@@ -28,10 +29,12 @@ public class SentCampaign extends Campaign {
     public String WebVersionTextURL;
     public Date SentDate;
     public int TotalRecipients;
+    public String[] Tags;
     
     @Override
     public String toString() {
-        return String.format("{ %s, SendDate: %s, WebVersionURL: %s, TotalRecipients: %d }", super.toString(), 
-                SentDate, WebVersionURL, TotalRecipients);
+        return String.format(
+            "{ %s, SendDate: %s, WebVersionURL: %s, WebVersionTextURL: %s, TotalRecipients: %d, Tags: %s }",
+            super.toString(), SentDate, WebVersionURL, WebVersionTextURL, TotalRecipients, Arrays.toString(Tags));
     }
 }

--- a/src/com/createsend/models/clients/Tag.java
+++ b/src/com/createsend/models/clients/Tag.java
@@ -1,0 +1,34 @@
+/**
+ * Copyright (c) 2021 Campaign Monitor
+ *
+ *  Permission is hereby granted, free of charge, to any person obtaining a copy
+ *  of this software and associated documentation files (the "Software"), to deal
+ *  in the Software without restriction, including without limitation the rights
+ *  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ *  copies of the Software, and to permit persons to whom the Software is
+ *  furnished to do so, subject to the following conditions:
+ *
+ *  The above copyright notice and this permission notice shall be included in
+ *  all copies or substantial portions of the Software.
+ *
+ *  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ *  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ *  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ *  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ *  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ *  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ *  THE SOFTWARE.
+ */
+package com.createsend.models.clients;
+
+public class Tag {
+  public String Name;
+  public int NumberOfCampaigns;
+
+  @Override
+  public String toString() {
+    return String.format(
+            "{ Name: %s, NumberOfCampaigns: %s }",
+            Name, NumberOfCampaigns);
+  }
+}

--- a/src/com/createsend/models/subscribers/SubscriberWithJoinedDate.java
+++ b/src/com/createsend/models/subscribers/SubscriberWithJoinedDate.java
@@ -1,0 +1,42 @@
+/**
+ * Copyright (c) 2021 Campaign Monitor
+ * 
+ *  Permission is hereby granted, free of charge, to any person obtaining a copy
+ *  of this software and associated documentation files (the "Software"), to deal
+ *  in the Software without restriction, including without limitation the rights
+ *  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ *  copies of the Software, and to permit persons to whom the Software is
+ *  furnished to do so, subject to the following conditions:
+ *  
+ *  The above copyright notice and this permission notice shall be included in
+ *  all copies or substantial portions of the Software.
+ *  
+ *  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ *  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ *  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ *  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ *  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ *  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ *  THE SOFTWARE.
+ */
+package com.createsend.models.subscribers;
+
+import java.util.Date;
+
+public class SubscriberWithJoinedDate {
+    public String ListID;
+    public String EmailAddress;
+    public String Name;
+    public Date Date;
+    public Date ListJoinedDate;
+    public String State; // TODO: Probably want to move this to an enum
+    public CustomField[] CustomFields;
+    public String ReadsEmailWith;
+    public ConsentToTrack ConsentToTrack;
+
+    @Override
+    public String toString() {
+        return String.format("{ ListID: %s, EmailAddress: %s, Name: %s, Date: %s, ListJoinedDate: %s, State: %s }",
+                ListID, EmailAddress, Name, Date, ListJoinedDate, State);
+    }
+}

--- a/src/com/createsend/util/config.properties
+++ b/src/com/createsend/util/config.properties
@@ -1,4 +1,4 @@
-createsend.version = 6.1.1
-createsend.endpoint = https://api.createsend.com/api/v3.2/
+createsend.version = 7.0.0
+createsend.endpoint = https://api.createsend.com/api/v3.3/
 createsend.oauthbaseuri = https://api.createsend.com/oauth/
 createsend.logging = false


### PR DESCRIPTION
Upgrades to Createsend API v3.3 which includes new breaking changes

* New client tags() returns the list of tags 
* Client draftCampaigns() now return Tags
* Client scheduledCampaigns() now returns Tags
* Revamped client sentCampaigns() includes these improvements: 
  * The method returns a PagedResult of SentCampaign.
  * Entries can be fetched using the Page parameter.
  * Up to 1000 entries are returned per method call. A different amount can be returned by setting the PageSize value.
  * Campaigns can be sorted by their Sent Date using OrderDirection
  * Campaigns can be filtered by Sent Date using sentFromDate and sentToDate in YYYY-MM-DD format
  * Campaigns can be filtered by their tags.
* Campaign summary() now returns Name