### PR TITLE
Detect rate limiting errors

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,5 +1,9 @@
 # createsend-java history
 
+## v7.0.1 - 2 December 2022
+
+* Added support for rate limiting errors
+
 ## v7.0.0 - 14 December 2021
 
 * Upgrades to Createsend API v3.3 which includes new breaking changes

--- a/build.gradle
+++ b/build.gradle
@@ -7,7 +7,7 @@ install.dependsOn ':build'
 defaultTasks 'clean', 'install'
 
 sourceCompatibility = 1.7
-version = '7.0.0'
+version = '7.0.1'
 group = 'com.createsend'
 
 def localMavenRepo = 'file://' + new File(System.getProperty('user.home'), '.m2/repository').absolutePath

--- a/src/com/createsend/util/exceptions/CreateSendHttpException.java
+++ b/src/com/createsend/util/exceptions/CreateSendHttpException.java
@@ -30,29 +30,45 @@ import com.sun.jersey.api.client.ClientResponse.Status;
 public class CreateSendHttpException extends CreateSendException {
     private static final long serialVersionUID = 6026680795882633621L;
 
-    private ClientResponse.Status httpStatusCode;
+    private int httpStatusCode;
     private int apiErrorCode;
     private String apiErrorMessage;
 
-    public CreateSendHttpException(Status httpStatusCode) {
+    public CreateSendHttpException(int httpStatusCode) {
         super("The API call failed due to an unexpected HTTP error: " + httpStatusCode);
         this.httpStatusCode = httpStatusCode;
         this.apiErrorMessage = "";
     }
 
+    public CreateSendHttpException(String message, int httpStatusCode) {
+        super(message);
+        this.httpStatusCode = httpStatusCode;
+        this.apiErrorMessage = apiErrorMessage;
+    }
+
     public CreateSendHttpException(String message, int httpStatusCode, int apiErrorCode, String apiErrorMessage) {
         super(message);
         
-        this.httpStatusCode = Status.fromStatusCode(httpStatusCode);
+        this.httpStatusCode = httpStatusCode;
         this.apiErrorCode = apiErrorCode;
         this.apiErrorMessage = apiErrorMessage;
     }
     
     /**
+     * @return The HTTP Status code as an integer from the failed request
+     */
+    public int getStatusCode() {
+        return httpStatusCode;
+    }
+
+    /**
+     * This method will only interpret well know HTTP Status Codes. Status codes such as 429 may
+     * not be correctly interpreted, in which case you can use {@link #getStatusCode}
+     *
      * @return The HTTP Status code from the failed request
      */
     public Status getHttpStatusCode() {
-        return httpStatusCode;
+        return Status.fromStatusCode(httpStatusCode);
     }
     
     /**

--- a/src/com/createsend/util/exceptions/RateLimitingException.java
+++ b/src/com/createsend/util/exceptions/RateLimitingException.java
@@ -1,0 +1,39 @@
+/**
+ * Copyright (c) 2011 Toby Brain
+ * 
+ *  Permission is hereby granted, free of charge, to any person obtaining a copy
+ *  of this software and associated documentation files (the "Software"), to deal
+ *  in the Software without restriction, including without limitation the rights
+ *  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ *  copies of the Software, and to permit persons to whom the Software is
+ *  furnished to do so, subject to the following conditions:
+ *  
+ *  The above copyright notice and this permission notice shall be included in
+ *  all copies or substantial portions of the Software.
+ *  
+ *  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ *  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ *  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ *  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ *  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ *  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ *  THE SOFTWARE.
+ */
+package com.createsend.util.exceptions;
+
+/**
+ * An exception raised when the Campaign Monitor API responds with a 400 Bad Request
+ */
+public class RateLimitingException extends CreateSendHttpException {
+    private static final long serialVersionUID = -2724621705342365927L;
+
+    public RateLimitingException(int apiErrorCode, String message) {
+        super(
+            String.format(
+                "The CreateSend API responded indicating that rate limiting occured%s",
+                message == null ? "" : ": " + message),
+            apiErrorCode,
+            apiErrorCode,
+            message == null ? "" : message);
+    }
+}

--- a/src/com/createsend/util/exceptions/RateLimitingException.java
+++ b/src/com/createsend/util/exceptions/RateLimitingException.java
@@ -22,7 +22,7 @@
 package com.createsend.util.exceptions;
 
 /**
- * An exception raised when the Campaign Monitor API responds with a 400 Bad Request
+ * An exception raised when the Campaign Monitor API responds with a 429 Too Many Requests
  */
 public class RateLimitingException extends CreateSendHttpException {
     private static final long serialVersionUID = -2724621705342365927L;


### PR DESCRIPTION
Jersey does not currently support Status Codes like `429:Too Many Requests` which is problematic.

Code has been added to detect cases where Jersey does not translate the Status Code correctly and deserialise any reponse payload. Furthermore, a response of `429` has been translated into a `RateLimitingException` given it forms one of the six error groupings of the Campaign Monitor API.